### PR TITLE
Prefer MemAvailable if present

### DIFF
--- a/modules/meminfo/meminfo.go
+++ b/modules/meminfo/meminfo.go
@@ -43,6 +43,11 @@ func (i Info) FreeFrac(k string) float64 {
 // Available returns the "available" system memory, including
 // currently cached memory that can be freed up if needed.
 func (i Info) Available() Bytes {
+	// MemAvailable, if present, is a more accurate indication of
+	// available memory.
+	if avail, ok := i["MemAvailable"]; ok {
+		return avail
+	}
 	return Bytes(uint64(i["MemFree"]) + uint64(i["Cached"]) + uint64(i["Buffers"]))
 }
 


### PR DESCRIPTION
MemAvailable in /proc/meminfo is more realistic estimate of available memory. See:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773