### PR TITLE
Don't assume mpris track ID is a string

### DIFF
--- a/modules/media/mpris.go
+++ b/modules/media/mpris.go
@@ -337,7 +337,7 @@ func (i *infoReader) updateMetadata() {
 		i.updates.metadata = true
 	}
 	if id, ok := metadata["mpris:trackid"]; ok {
-		trackID := id.Value().(string)
+		trackID := id.String()
 		if trackID != i.trackID {
 			// mpris suggests that position should be reset on track change.
 			i.lastPosition = 0


### PR DESCRIPTION
Quodlibet seems to use the "object path" type when reporting the track ID. This was causing track ID conversion to panic. As it's only used to detect track changes, the generic dbus.Variant string conversion should work for any track ID type.