### PR TITLE
Use go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
-go:
-        - 1.8
+go: "1.10"
 
 before_install:
         - sudo apt-get -qq update


### PR DESCRIPTION
Update travis.yml to use go 1.10 (which requires a string version, otherwise we end up with go 1.1!)