### PR TITLE
Simplify output types

### DIFF
--- a/bar/bar.go
+++ b/bar/bar.go
@@ -61,8 +61,10 @@ See output.go for supported methods.
 */
 type Segment map[string]interface{}
 
-// Output groups together one or more segments to display on the bar.
-type Output []Segment
+// Output is an interface for displaying objects on the bar.
+type Output interface {
+	Segments() []Segment
+}
 
 // Button represents an X11 mouse button.
 type Button int

--- a/bar/bar_test.go
+++ b/bar/bar_test.go
@@ -142,18 +142,18 @@ func TestMultipleModules(t *testing.T) {
 	assert.Equal(t, []string{"test", "middle", "new value"}, out,
 		"newly updated module correctly repositions other modules")
 
-	module1.Output(Output{})
+	module1.Output(outputs.Empty())
 	out = readOutputTexts(t, mockStdout)
 	assert.Equal(t, []string{"middle", "new value"}, out,
 		"nil output correctly repositions other modules")
 }
 
 func multiOutput(texts ...string) Output {
-	m := outputs.Multi()
-	for idx, text := range texts {
-		m.AddText(fmt.Sprintf("instance_%d", idx), text)
+	m := SegmentGroup{}
+	for _, text := range texts {
+		m = append(m, NewSegment(text))
 	}
-	return m.Build()
+	return m
 }
 
 func TestMultiSegmentModule(t *testing.T) {

--- a/bar/output.go
+++ b/bar/output.go
@@ -16,58 +16,62 @@ package bar
 
 import "math"
 
-// Color sets the color for all segments in the output.
-func (o Output) Color(color Color) Output {
-	for _, s := range o {
+// SegmentGroup represents a group of Segments to be
+// displayed together on the bar.
+type SegmentGroup []Segment
+
+// Color sets the color for all segments in the group.
+func (g SegmentGroup) Color(color Color) SegmentGroup {
+	for _, s := range g {
 		s.Color(color)
 	}
-	return o
+	return g
 }
 
-// Background sets the background color for all segments in the output.
-func (o Output) Background(background Color) Output {
-	for _, s := range o {
+// Background sets the background color for all segments in the group.
+func (g SegmentGroup) Background(background Color) SegmentGroup {
+	for _, s := range g {
 		s.Background(background)
 	}
-	return o
+	return g
 }
 
-// Border sets the border color for all segments in the output.
-func (o Output) Border(border Color) Output {
-	for _, s := range o {
+// Border sets the border color for all segments in the group.
+func (g SegmentGroup) Border(border Color) SegmentGroup {
+	for _, s := range g {
 		s.Border(border)
 	}
-	return o
+	return g
 }
 
-// Align sets the text alignment for all segments in the output.
-func (o Output) Align(align TextAlignment) Output {
-	for _, s := range o {
+// Align sets the text alignment for all segments in the group.
+func (g SegmentGroup) Align(align TextAlignment) SegmentGroup {
+	for _, s := range g {
 		s.Align(align)
 	}
-	return o
+	return g
 }
 
-// Urgent sets the urgency flag for all segments in the output.
-func (o Output) Urgent(urgent bool) Output {
-	for _, s := range o {
+// Urgent sets the urgency flag for all segments in the group.
+func (g SegmentGroup) Urgent(urgent bool) SegmentGroup {
+	for _, s := range g {
 		s.Urgent(urgent)
 	}
-	return o
+	return g
 }
 
-// Markup sets the markup type for all segments in the output.
-func (o Output) Markup(markup Markup) Output {
-	for _, s := range o {
+// Markup sets the markup type for all segments in the group.
+func (g SegmentGroup) Markup(markup Markup) SegmentGroup {
+	for _, s := range g {
 		s.Markup(markup)
 	}
-	return o
+	return g
 }
 
 /*
 Width and separator(width) are treated specially such that the methods
 make sense when called on a single-segment output (such as the result
-of outputs.Textf(...)) as well as when called on a multi-segment output.
+of outputs.Textf(...)) as well as when called on a multi-segment group.
 
 To that end, min-width distributes the minimum width equally amongst
 all segments, and separator(width) only operate on the last segment.
@@ -77,52 +81,57 @@ last segment.
 */
 
 // MinWidth sets the minimum width for the output, by (mostly) equally
-// distributing the given minWidth amongst all segments in the output.
-func (o Output) MinWidth(minWidth int) Output {
+// distributing the given minWidth amongst all segments in the group.
+func (g SegmentGroup) MinWidth(minWidth int) SegmentGroup {
 	remainingWidth := float64(minWidth)
-	for idx, s := range o {
-		remainingSegments := float64(len(o) - idx)
+	for idx, s := range g {
+		remainingSegments := float64(len(g) - idx)
 		myWidth := math.Floor(remainingWidth/remainingSegments + 0.5)
 		s.MinWidth(int(myWidth))
 		remainingWidth = remainingWidth - myWidth
 	}
-	return o
+	return g
 }
 
-// Separator sets the separator visibility of the last segment in the output.
-func (o Output) Separator(separator bool) Output {
-	if len(o) > 0 {
-		o[len(o)-1].Separator(separator)
+// Separator sets the separator visibility of the last segment in the group.
+func (g SegmentGroup) Separator(separator bool) SegmentGroup {
+	if len(g) > 0 {
+		g[len(g)-1].Separator(separator)
 	}
-	return o
+	return g
 }
 
-// SeparatorWidth sets the separator width of the last segment in the output.
-func (o Output) SeparatorWidth(separatorWidth int) Output {
-	if len(o) > 0 {
-		o[len(o)-1].SeparatorWidth(separatorWidth)
+// SeparatorWidth sets the separator width of the last segment in the group.
+func (g SegmentGroup) SeparatorWidth(separatorWidth int) SegmentGroup {
+	if len(g) > 0 {
+		g[len(g)-1].SeparatorWidth(separatorWidth)
 	}
-	return o
+	return g
 }
 
-// InnerSeparator sets the separator visibility between segments of this output.
-func (o Output) InnerSeparator(separator bool) Output {
-	for idx, s := range o {
-		if idx+1 < len(o) {
+// InnerSeparator sets the separator visibility between segments of this group.
+func (g SegmentGroup) InnerSeparator(separator bool) SegmentGroup {
+	for idx, s := range g {
+		if idx+1 < len(g) {
 			s.Separator(separator)
 		}
 	}
-	return o
+	return g
 }
 
-// InnerSeparatorWidth sets the separator width between segments of this output.
-func (o Output) InnerSeparatorWidth(separatorWidth int) Output {
-	for idx, s := range o {
-		if idx+1 < len(o) {
+// InnerSeparatorWidth sets the separator width between segments of this group.
+func (g SegmentGroup) InnerSeparatorWidth(separatorWidth int) SegmentGroup {
+	for idx, s := range g {
+		if idx+1 < len(g) {
 			s.SeparatorWidth(separatorWidth)
 		}
 	}
-	return o
+	return g
+}
+
+// Segments trivially implements bar.Output for SegmentGroup.
+func (g SegmentGroup) Segments() []Segment {
+	return g
 }
 
 // NewSegment creates a new output segment with text content.
@@ -210,4 +219,9 @@ func (s Segment) Markup(markup Markup) Segment {
 func (s Segment) Instance(instance string) Segment {
 	s["instance"] = instance
 	return s
+}
+
+// Segments implements bar.Output for a single Segment.
+func (s Segment) Segments() []Segment {
+	return []Segment{s}
 }

--- a/bar/output_test.go
+++ b/bar/output_test.go
@@ -91,8 +91,8 @@ func TestSegment(t *testing.T) {
 	a.AssertEqual("opaque instance")
 }
 
-func TestOutput(t *testing.T) {
-	out := Output{
+func TestGroup(t *testing.T) {
+	out := SegmentGroup{
 		NewSegment("1"),
 		NewSegment("2"),
 		NewSegment("3"),
@@ -177,7 +177,7 @@ func TestOutput(t *testing.T) {
 	mid.Expected["separator"] = "false"
 	assertAllEqual("inner separator only affects inner segments")
 
-	single := Output{NewSegment("only")}
+	single := SegmentGroup{NewSegment("only")}
 	a := segmentAssertions(t, single[0])
 	a.Expected["full_text"] = "only"
 	single.Background(Color("yellow"))
@@ -195,7 +195,7 @@ func TestOutput(t *testing.T) {
 	a.AssertEqual("setting properties on a single segment output work")
 
 	// Sanity check properties where the number of segments matters.
-	empty := Output{}
+	empty := SegmentGroup{}
 	empty.MinWidth(100)
 	empty.Separator(true)
 	empty.SeparatorWidth(0)

--- a/bar/run.go
+++ b/bar/run.go
@@ -61,7 +61,7 @@ type i3Module struct {
 func (m *i3Module) output(ch chan<- interface{}) {
 	for o := range m.Stream() {
 		var i3out i3Output
-		for _, segment := range o {
+		for _, segment := range o.Segments() {
 			segment["name"] = m.Name
 			i3out = append(i3out, segment)
 		}

--- a/base/base_test.go
+++ b/base/base_test.go
@@ -76,10 +76,10 @@ func TestUpdateAndScheduler(t *testing.T) {
 	updateCalled := false
 	b.OnUpdate(func() {
 		updateCalled = true
-		b.Output(bar.Output{bar.NewSegment("test")})
+		b.Output(bar.NewSegment("test"))
 	})
 
-	assertUpdate := func(message string) bar.Output {
+	assertUpdate := func(message string) []bar.Segment {
 		out := o.AssertOutput(message)
 		assert.True(t, updateCalled, message)
 		updateCalled = false
@@ -118,7 +118,7 @@ func TestPauseResume(t *testing.T) {
 	})
 	o := testModule.NewOutputTester(t, b)
 
-	assertUpdate := func(message string) bar.Output {
+	assertUpdate := func(message string) []bar.Segment {
 		out := o.AssertOutput(message)
 		assert.True(t, updateCalled, message)
 		updateCalled = false
@@ -165,7 +165,7 @@ func TestPauseResume(t *testing.T) {
 
 	b.Resume()
 	out := o.AssertOutput("from calling output while paused")
-	assert.Equal(t, newOut, out, "updates with last output")
+	assert.Equal(t, newOut.Segments(), out, "updates with last output")
 	o.AssertNoOutput("only last output emitted on resume")
 }
 

--- a/modules/battery/battery.go
+++ b/modules/battery/battery.go
@@ -169,7 +169,7 @@ func (m *module) UrgentWhen(urgentFunc func(Info) bool) Module {
 func (m *module) update() {
 	info := batteryInfo(m.batteryName)
 	m.Lock()
-	out := m.outputFunc(info)
+	out := outputs.Group(m.outputFunc(info))
 	if m.urgentFunc != nil {
 		out.Urgent(m.urgentFunc(info))
 	}

--- a/modules/battery/battery_test.go
+++ b/modules/battery/battery_test.go
@@ -183,7 +183,7 @@ func TestSimple(t *testing.T) {
 	bat2 := New("BAT2").
 		UrgentWhen(capLt30).
 		OutputFunc(func(i Info) bar.Output {
-			return bar.Output{bar.NewSegment(i.Technology)}
+			return bar.NewSegment(i.Technology)
 		}).
 		RefreshInterval(150 * time.Millisecond)
 

--- a/modules/cpuload/cpuload.go
+++ b/modules/cpuload/cpuload.go
@@ -136,7 +136,7 @@ func (m *module) update() {
 		return
 	}
 	m.Lock()
-	out := m.outputFunc(m.loads)
+	out := outputs.Group(m.outputFunc(m.loads))
 	if m.urgentFunc != nil {
 		out.Urgent(m.urgentFunc(m.loads))
 	}

--- a/modules/cpuload/cpuload_test.go
+++ b/modules/cpuload/cpuload_test.go
@@ -114,17 +114,17 @@ func TestCpuload(t *testing.T) {
 	shouldReturn(1)
 	scheduler.NextTick()
 	out = tester.AssertOutput("on next tick")
-	assert.Equal(outputs.Error(fmt.Errorf("getloadavg: 1")), out)
+	assert.Equal(outputs.Error(fmt.Errorf("getloadavg: 1")).Segments(), out)
 
 	shouldReturn(1, 2, 3, 4, 5)
 	scheduler.NextTick()
 	out = tester.AssertOutput("on next tick")
-	assert.Equal(outputs.Error(fmt.Errorf("getloadavg: 5")), out)
+	assert.Equal(outputs.Error(fmt.Errorf("getloadavg: 5")).Segments(), out)
 
 	shouldError(fmt.Errorf("test"))
 	scheduler.NextTick()
 	out = tester.AssertOutput("on next tick")
-	assert.Equal(outputs.Error(fmt.Errorf("test")), out)
+	assert.Equal(outputs.Error(fmt.Errorf("test")).Segments(), out)
 
 	load.RefreshInterval(time.Minute)
 	tester.AssertNoOutput("on refresh interval change")

--- a/modules/cputemp/cputemp.go
+++ b/modules/cputemp/cputemp.go
@@ -147,7 +147,7 @@ func (m *module) update() {
 	}
 	temp := Temperature(float64(milliC) / 1000.0)
 	m.Lock()
-	out := m.outputFunc(temp)
+	out := outputs.Group(m.outputFunc(temp))
 	if m.urgentFunc != nil {
 		out.Urgent(m.urgentFunc(temp))
 	}

--- a/modules/cputemp/cputemp_test.go
+++ b/modules/cputemp/cputemp_test.go
@@ -56,10 +56,10 @@ func TestCputemp(t *testing.T) {
 	tester2 := testModule.NewOutputTester(t, temp2)
 
 	out := tester0.AssertOutput("on start")
-	assert.Equal(outputs.Text("49"), out)
+	assert.Equal(outputs.Text("49").Segments(), out)
 
 	out = tester1.AssertOutput("on start")
-	assert.Equal(outputs.Text("72"), out)
+	assert.Equal(outputs.Text("72").Segments(), out)
 
 	tester2.AssertError("on start with invalid zone")
 
@@ -71,13 +71,13 @@ func TestCputemp(t *testing.T) {
 	scheduler.NextTick()
 
 	out = tester0.AssertOutput("on next tick")
-	assert.Equal(outputs.Text("42"), out)
+	assert.Equal(outputs.Text("42").Segments(), out)
 	tester1.AssertOutput("on next tick")
 	tester2.AssertError("on each tick")
 
 	temp0.UrgentWhen(func(t Temperature) bool { return t.C() > 30 })
 	out = tester0.AssertOutput("on urgent func change")
-	assert.Equal(outputs.Text("42").Urgent(true), out)
+	assert.Equal(outputs.Text("42").Urgent(true).Segments(), out)
 
 	red := bar.Color("red")
 	green := bar.Color("green")
@@ -88,7 +88,7 @@ func TestCputemp(t *testing.T) {
 		return green
 	})
 	out = tester1.AssertOutput("on color func change")
-	assert.Equal(outputs.Text("68").Color(green), out)
+	assert.Equal(outputs.Text("68").Color(green).Segments(), out)
 
 	temp2.OutputTemplate(outputs.TextTemplate(`{{.K}} kelvin`))
 	tester2.AssertError("error persists even with template change")
@@ -97,10 +97,10 @@ func TestCputemp(t *testing.T) {
 	scheduler.NextTick()
 
 	out = tester0.AssertOutput("on next tick")
-	assert.Equal(outputs.Text("22").Urgent(false), out)
+	assert.Equal(outputs.Text("22").Urgent(false).Segments(), out)
 
 	out = tester1.AssertOutput("on next tick")
-	assert.Equal(outputs.Text("72").Color(red), out)
+	assert.Equal(outputs.Text("72").Color(red).Segments(), out)
 
 	tester2.AssertError("on each tick")
 
@@ -112,7 +112,7 @@ func TestCputemp(t *testing.T) {
 	// Only temp2 has an update, since temp0 and temp1 are still
 	// on the 3 second refresh interval.
 	out = tester2.AssertOutput("on next tick when zone becomes available")
-	assert.Equal(outputs.Text("273 kelvin"), out)
+	assert.Equal(outputs.Text("273 kelvin").Segments(), out)
 
 	shouldReturn("0", "0", "invalid")
 	scheduler.NextTick()

--- a/modules/diskio/diskio_test.go
+++ b/modules/diskio/diskio_test.go
@@ -73,7 +73,7 @@ func TestDiskIo(t *testing.T) {
 
 	out := tester1.AssertOutput("on tick")
 	// 9+9 sectors / 3 seconds = 6 sectors / second * 512 bytes / sector = 3027 bytes.
-	assert.Equal(outputs.Text("3072"), out)
+	assert.Equal(outputs.Text("3072").Segments(), out)
 
 	// Simpler math.
 	RefreshInterval(time.Second)
@@ -95,7 +95,7 @@ func TestDiskIo(t *testing.T) {
 	<-signalChan
 
 	out = tester1.AssertOutput("on tick")
-	assert.Equal(outputs.Text("512"), out)
+	assert.Equal(outputs.Text("512").Segments(), out)
 
 	tester2.AssertNoOutput("for missing disk")
 
@@ -107,7 +107,7 @@ func TestDiskIo(t *testing.T) {
 	<-signalChan
 
 	out = tester1.AssertOutput("on tick")
-	assert.Equal(outputs.Text("0"), out)
+	assert.Equal(outputs.Text("0").Segments(), out)
 
 	sda1.OutputFunc(func(i IO) bar.Output {
 		return outputs.Textf("%s", i.Total().SI())
@@ -115,7 +115,7 @@ func TestDiskIo(t *testing.T) {
 	<-signalChan
 
 	out = tester1.AssertOutput("on output func change")
-	assert.Equal(outputs.Text("0 B"), out)
+	assert.Equal(outputs.Text("0 B").Segments(), out)
 
 	tester2.AssertNoOutput("for missing disk")
 
@@ -141,7 +141,7 @@ func TestDiskIo(t *testing.T) {
 	tester1.AssertNoOutput("for missing disk")
 
 	out = tester2.AssertOutput("on tick")
-	assert.Equal(outputs.Text("50 KiB"), out)
+	assert.Equal(outputs.Text("50 KiB").Segments(), out)
 }
 
 func TestErrors(t *testing.T) {
@@ -199,7 +199,7 @@ a b sda2 0 0 100 0 0 0 b 0 0 0 0
 	<-signalChan
 
 	out := tester.AssertOutput("on second tick")
-	assert.Equal(t, outputs.Textf("Disk: 100 KiB/s"), out,
+	assert.Equal(t, outputs.Textf("Disk: 100 KiB/s").Segments(), out,
 		"ignores invalid lines in diskstats")
 }
 

--- a/modules/diskspace/diskspace.go
+++ b/modules/diskspace/diskspace.go
@@ -178,7 +178,7 @@ func (m *module) update() {
 		Free:      Bytes(m.statResult.Bfree * mult),
 		Total:     Bytes(m.statResult.Blocks * mult),
 	}
-	out := m.outputFunc(info)
+	out := outputs.Group(m.outputFunc(info))
 	if m.urgentFunc != nil {
 		out.Urgent(m.urgentFunc(info))
 	}

--- a/modules/diskspace/diskspace_test.go
+++ b/modules/diskspace/diskspace_test.go
@@ -80,7 +80,7 @@ func TestDiskspace(t *testing.T) {
 	})
 
 	out := tester.AssertOutput("on start")
-	assert.Equal(outputs.Text("0.50 GB"), out)
+	assert.Equal(outputs.Text("0.50 GB").Segments(), out)
 
 	shouldReturn("/", unix.Statfs_t{
 		Bsize:  1000 * 1000,
@@ -98,7 +98,7 @@ func TestDiskspace(t *testing.T) {
 	})
 	scheduler.NextTick()
 	out = tester.AssertOutput("on next tick")
-	assert.Equal(outputs.Text("2.00 GB"), out)
+	assert.Equal(outputs.Text("2.00 GB").Segments(), out)
 
 	shouldReturn("/", unix.Statfs_t{
 		Bsize:  1000 * 1000,
@@ -108,7 +108,7 @@ func TestDiskspace(t *testing.T) {
 	})
 	diskspace.OutputTemplate(outputs.TextTemplate(`{{.Available.In "MB" | printf "%.1f"}}`))
 	out = tester.AssertOutput("on output format change")
-	assert.Equal(outputs.Text("500.0"), out)
+	assert.Equal(outputs.Text("500.0").Segments(), out)
 
 	diskspace.UrgentWhen(func(i Info) bool {
 		return i.AvailFrac() < 0.5
@@ -214,5 +214,5 @@ func TestNonexistentDiskspace(t *testing.T) {
 	})
 	scheduler.NextTick()
 	out := tester.AssertOutput("on next tick after mounting")
-	assert.Equal(outputs.Text("6.00 GB"), out)
+	assert.Equal(outputs.Text("6.00 GB").Segments(), out)
 }

--- a/modules/group/collapsing_test.go
+++ b/modules/group/collapsing_test.go
@@ -34,7 +34,7 @@ func TestCollapsingEmpty(t *testing.T) {
 
 	module := testModule.New(t)
 	tester := testModule.NewOutputTester(t, group.Add(module))
-	module.Output(bar.Output{bar.NewSegment("test")})
+	module.Output(bar.NewSegment("test"))
 	tester.AssertNoOutput("adding to collapsed group")
 }
 
@@ -49,34 +49,35 @@ func TestCollapsingWithModule(t *testing.T) {
 	tester := testModule.NewOutputTester(t, wrapped)
 	module.AssertStarted("when wrapping module is started")
 
-	out := bar.Output{bar.NewSegment("hello")}
+	out := bar.NewSegment("hello")
 	module.Output(out)
 	wOut := tester.AssertOutput("passes thru when expanded")
-	assert.Equal(t, out, wOut, "output is unchanged")
+	assert.Equal(t, out.Segments(), wOut, "output is unchanged")
 
 	group.Collapse()
 	tester.AssertEmpty("on collapse")
 
 	group.Expand()
 	wOut = tester.AssertOutput("on expand")
-	assert.Equal(t, out, wOut, "original output re-sent")
+	assert.Equal(t, out.Segments(), wOut, "original output re-sent")
 
 	group.Toggle()
 	assert.True(t, group.Collapsed(), "state check")
 	tester.AssertEmpty("on collapse")
-	out2 := bar.Output{bar.NewSegment("world")}
+	out2 := bar.NewSegment("world")
 	module.Output(out2)
 	tester.AssertNoOutput("while collapsed")
 
 	group.Toggle()
 	assert.False(t, group.Collapsed(), "state check")
 	wOut = tester.AssertOutput("on expand")
-	assert.Equal(t, out2, wOut, "output while collapsed is not discarded")
+	assert.Equal(t, out2.Segments(), wOut,
+		"output while collapsed is not discarded")
 
-	out3 := bar.Output{bar.NewSegment("foo")}
+	out3 := bar.NewSegment("foo")
 	module.Output(out3)
 	wOut = tester.AssertOutput("passes thru when expanded")
-	assert.Equal(t, out3, wOut, "works normally when expanded")
+	assert.Equal(t, out3.Segments(), wOut, "works normally when expanded")
 
 	wrapped.(bar.Pausable).Pause()
 	module.AssertPaused("when wrapper is paused")
@@ -92,23 +93,23 @@ func TestCollapsingWithModule(t *testing.T) {
 func TestCollapsingButton(t *testing.T) {
 	group := Collapsing()
 	leftClick := bar.Event{Button: bar.ButtonLeft}
-	col := bar.Output{bar.NewSegment("col")}
-	exp := bar.Output{bar.NewSegment("exp")}
+	col := bar.NewSegment("collapsed")
+	exp := bar.NewSegment("expanded")
 
 	button := group.Button(col, exp)
 	buttonTester := testModule.NewOutputTester(t, button)
 
 	out := buttonTester.AssertOutput("initial output")
-	assert.Equal(t, exp, out, "starts expanded")
+	assert.Equal(t, exp.Segments(), out, "starts expanded")
 
 	button.Click(leftClick)
 	out = buttonTester.AssertOutput("when clicked")
-	assert.Equal(t, col, out, "collapsed")
+	assert.Equal(t, col.Segments(), out, "collapsed")
 	assert.True(t, group.Collapsed(), "collapsed")
 
 	button.Click(leftClick)
 	out = buttonTester.AssertOutput("when clicked")
-	assert.Equal(t, exp, out, "expanded")
+	assert.Equal(t, exp.Segments(), out, "expanded")
 	assert.False(t, group.Collapsed(), "expanded")
 
 	buttonTester.AssertNoOutput("no output without interaction")

--- a/modules/group/cycling_test.go
+++ b/modules/group/cycling_test.go
@@ -38,7 +38,7 @@ func TestCyclingWithModules(t *testing.T) {
 	group := Cycling()
 
 	module1 := testModule.New(t)
-	out1 := bar.Output{bar.NewSegment("1")}
+	out1 := bar.NewSegment("1")
 	wrapped1 := group.Add(module1)
 	module1.AssertNotStarted("when wrapped")
 
@@ -48,13 +48,13 @@ func TestCyclingWithModules(t *testing.T) {
 	tester1.AssertOutput("first module starts visible")
 
 	module2 := testModule.New(t)
-	out2 := bar.Output{bar.NewSegment("2")}
+	out2 := bar.NewSegment("2")
 	tester2 := testModule.NewOutputTester(t, group.Add(module2))
 	module2.Output(out2)
 	tester2.AssertNoOutput("other modules start hidden")
 
 	module3 := testModule.New(t)
-	out3 := bar.Output{bar.NewSegment("3")}
+	out3 := bar.NewSegment("3")
 	tester3 := testModule.NewOutputTester(t, group.Add(module3))
 	module3.Output(out3)
 	tester3.AssertNoOutput("other modules start hidden")
@@ -63,32 +63,36 @@ func TestCyclingWithModules(t *testing.T) {
 	assert.Equal(t, 1, group.Visible(), "updates visible index")
 	tester1.AssertEmpty("on switch")
 	wOut := tester2.AssertOutput("shows next module on switch")
-	assert.Equal(t, out2, wOut, "updates with previous output")
+	assert.Equal(t, out2.Segments(), wOut,
+		"updates with previous output")
 	tester3.AssertNoOutput("only two modules updated at a time")
 
 	group.Previous()
 	assert.Equal(t, 0, group.Visible(), "updates visible index")
 	tester2.AssertEmpty("previous output on switch")
 	wOut = tester1.AssertOutput("shows next module on switch")
-	assert.Equal(t, out1, wOut, "updates with previous output")
+	assert.Equal(t, out1.Segments(), wOut,
+		"updates with previous output")
 	tester3.AssertNoOutput("only two modules updated at a time")
 
 	group.Show(2)
 	assert.Equal(t, 2, group.Visible(), "updates visible index")
 	tester1.AssertEmpty("previous output on switch")
 	wOut = tester3.AssertOutput("shows next module on switch")
-	assert.Equal(t, out3, wOut, "updates with previous output")
+	assert.Equal(t, out3.Segments(), wOut,
+		"updates with previous output")
 	tester2.AssertNoOutput("only two modules updated at a time")
 
-	out4 := bar.Output{bar.NewSegment("4")}
+	out4 := bar.NewSegment("4")
 	module2.Output(out4)
 	tester2.AssertNoOutput("while hidden")
-	out5 := bar.Output{bar.NewSegment("5")}
+	out5 := bar.NewSegment("5")
 	module2.Output(out5)
 	tester2.AssertNoOutput("while hidden")
 	group.Show(1)
 	wOut = tester2.AssertOutput("when visible")
-	assert.Equal(t, out5, wOut, "updates while hidden coalesced")
+	assert.Equal(t, out5.Segments(), wOut,
+		"updates while hidden coalesced")
 }
 
 func TestCyclingButton(t *testing.T) {
@@ -98,7 +102,7 @@ func TestCyclingButton(t *testing.T) {
 	for i := 0; i <= 3; i++ {
 		group.Add(testModule.New(t)).Stream()
 	}
-	button := group.Button(bar.Output{})
+	button := group.Button(bar.NewSegment("<>"))
 	assert.Equal(t, 0, group.Visible(), "starts with first module")
 	button.Click(leftClick)
 	assert.Equal(t, 1, group.Visible(), "switches to next module on click")

--- a/modules/meminfo/meminfo_test.go
+++ b/modules/meminfo/meminfo_test.go
@@ -55,7 +55,7 @@ func TestMeminfo(t *testing.T) {
 
 	tester1 := testModule.NewOutputTester(t, avail)
 	out := tester1.AssertOutput("on start")
-	assert.Equal(outputs.Text("2048"), out)
+	assert.Equal(outputs.Text("2048").Segments(), out)
 
 	shouldReturn(meminfo{
 		"MemAvailable": 1024,
@@ -66,13 +66,13 @@ func TestMeminfo(t *testing.T) {
 	scheduler.NextTick()
 
 	out = tester1.AssertOutput("on tick")
-	assert.Equal(outputs.Text("1024"), out)
+	assert.Equal(outputs.Text("1024").Segments(), out)
 
 	free := m.OutputTemplate(outputs.TextTemplate(`{{.FreeFrac "Mem"}}`))
 
 	tester2 := testModule.NewOutputTester(t, free)
 	out = tester2.AssertOutput("on start")
-	assert.Equal(outputs.Text("0.0625"), out)
+	assert.Equal(outputs.Text("0.0625").Segments(), out)
 
 	tester1.Drain()
 
@@ -85,10 +85,10 @@ func TestMeminfo(t *testing.T) {
 	scheduler.NextTick()
 
 	out = tester1.AssertOutput("on tick")
-	assert.Equal(outputs.Text("2048"), out)
+	assert.Equal(outputs.Text("2048").Segments(), out)
 
 	out = tester2.AssertOutput("on tick")
-	assert.Equal(outputs.Text("0.125"), out)
+	assert.Equal(outputs.Text("0.125").Segments(), out)
 
 	beforeTick := scheduler.Now()
 	m.RefreshInterval(time.Minute)
@@ -147,13 +147,13 @@ func TestErrors(t *testing.T) {
 	scheduler.NextTick()
 
 	out := tester.AssertOutput("when meminfo is back to normal")
-	assert.Equal(t, outputs.Textf("0.5"), out)
+	assert.Equal(t, outputs.Textf("0.5").Segments(), out)
 
 	out = tester1.AssertOutput("when meminfo is back to normal")
-	assert.Equal(t, outputs.Textf("1.0 MiB"), out)
+	assert.Equal(t, outputs.Textf("1.0 MiB").Segments(), out)
 
 	out = tester2.AssertOutput("when meminfo is back to normal")
-	assert.Equal(t, outputs.Textf("2.1 MB"), out)
+	assert.Equal(t, outputs.Textf("2.1 MB").Segments(), out)
 }
 
 // TODO: Remove this and spec out a "units" package.
@@ -165,5 +165,5 @@ func TestInvalidBaseInParse(t *testing.T) {
 	submodule := m.OutputTemplate(outputs.TextTemplate(`{{.MemTotal.In "foo"}}`))
 	tester := testModule.NewOutputTester(t, submodule)
 	out := tester.AssertOutput("on start")
-	assert.Equal(t, outputs.Text("1024"), out)
+	assert.Equal(t, outputs.Text("1024").Segments(), out)
 }

--- a/modules/netspeed/netspeed_test.go
+++ b/modules/netspeed/netspeed_test.go
@@ -87,7 +87,7 @@ func TestNetspeed(t *testing.T) {
 	scheduler.NextTick()
 
 	out := tester.AssertOutput("on tick")
-	assert.Equal(outputs.Text("3/1"), out)
+	assert.Equal(outputs.Text("3/1").Segments(), out)
 
 	setLink("if0", netlink.LinkStatistics{
 		RxBytes: 8192,
@@ -96,28 +96,32 @@ func TestNetspeed(t *testing.T) {
 	scheduler.NextTick()
 
 	out = tester.AssertOutput("on tick")
-	assert.Equal(outputs.Text("4/1"), out)
+	assert.Equal(outputs.Text("4/1").Segments(), out)
 
 	n.OutputTemplate(outputs.TextTemplate(`{{.Total.IEC}}`))
 	out = tester.AssertOutput("on output function change")
-	assert.Equal(outputs.Text("5.0 KiB"), out, "uses previous result")
+	assert.Equal(outputs.Text("5.0 KiB").Segments(), out,
+		"uses previous result")
 
 	n.OutputTemplate(outputs.TextTemplate(`{{.Total.SI}}`))
 	out = tester.AssertOutput("on output function change")
-	assert.Equal(outputs.Text("5.1 kB"), out, "uses previous result")
+	assert.Equal(outputs.Text("5.1 kB").Segments(), out,
+		"uses previous result")
 
 	n.OutputTemplate(outputs.TextTemplate(`{{.Tx.In "blahblah"}}`))
 	out = tester.AssertOutput("on output function change")
-	assert.Equal(outputs.Text("1024"), out, "bad unit defaults to bytes")
+	assert.Equal(outputs.Text("1024").Segments(), out,
+		"bad unit defaults to bytes")
 
 	scheduler.NextTick()
 	out = tester.AssertOutput("on tick after output function change")
-	assert.Equal(outputs.Text("0"), out)
+	assert.Equal(outputs.Text("0").Segments(), out)
 
 	beforeTick := scheduler.Now()
 	n.RefreshInterval(time.Minute)
 	scheduler.NextTick()
-	assert.Equal(time.Minute, scheduler.Now().Sub(beforeTick), "RefreshInterval change")
+	assert.Equal(time.Minute, scheduler.Now().Sub(beforeTick),
+		"RefreshInterval change")
 
 	tester.Drain()
 }
@@ -149,7 +153,7 @@ func TestErrors(t *testing.T) {
 	})
 	scheduler.NextTick()
 	out := tester.AssertOutput("on tick")
-	assert.Equal(t, outputs.Text("4/2"), out)
+	assert.Equal(t, outputs.Text("4/2").Segments(), out)
 }
 
 // TODO: Remove this and spec out a "units" package.
@@ -176,5 +180,5 @@ func TestInvalidBaseInParse(t *testing.T) {
 	scheduler.NextTick()
 
 	out := tester.AssertOutput("after one tick")
-	assert.Equal(t, outputs.Text("4096/2048"), out)
+	assert.Equal(t, outputs.Text("4096/2048").Segments(), out)
 }

--- a/modules/reformat/reformat_test.go
+++ b/modules/reformat/reformat_test.go
@@ -27,7 +27,7 @@ import (
 func TestReformat(t *testing.T) {
 	original := testModule.New(t)
 	reformatted := New(original, func(o bar.Output) bar.Output {
-		return outputs.Textf("+%s+", o[0].Text())
+		return outputs.Textf("+%s+", o.Segments()[0].Text())
 	})
 	original.AssertNotStarted("on construction of reformatted module")
 	tester := testModule.NewOutputTester(t, reformatted)

--- a/modules/shell/shell_test.go
+++ b/modules/shell/shell_test.go
@@ -31,7 +31,7 @@ func TestTail(t *testing.T) {
 
 	for _, i := range []string{"1", "2", "3", "4", "5"} {
 		out := tester.AssertOutput(i)
-		assert.Equal(t, out, outputs.Text(i))
+		assert.Equal(t, outputs.Text(i).Segments(), out)
 	}
 
 	tester.AssertNoOutput("when command terminates normally")
@@ -40,7 +40,7 @@ func TestTail(t *testing.T) {
 	tester = testModule.NewOutputTester(t, tail)
 	for _, i := range []string{"1", "2", "3"} {
 		out := tester.AssertOutput(i)
-		assert.Equal(t, outputs.Text(i), out)
+		assert.Equal(t, outputs.Text(i).Segments(), out)
 	}
 
 	tester.AssertError("when command terminates with an error")
@@ -57,11 +57,12 @@ func TestEvery(t *testing.T) {
 	tester := testModule.NewOutputTester(t, rep)
 
 	out := tester.AssertOutput("on start")
-	assert.Equal(t, outputs.Text("foo"), out)
+	assert.Equal(t, outputs.Text("foo").Segments(), out)
 
 	then := scheduler.Now()
 	now := scheduler.NextTick()
-	assert.InDelta(t, time.Second, now.Sub(then), float64(time.Millisecond))
+	assert.InDelta(t, float64(time.Second), float64(now.Sub(then)),
+		float64(time.Millisecond))
 
 	tester.AssertOutput("on tick")
 	tester.AssertNoOutput("until tick")
@@ -79,7 +80,7 @@ func TestEvery(t *testing.T) {
 func TestOnce(t *testing.T) {
 	tester := testModule.NewOutputTester(t, Once("echo", "bar"))
 	out := tester.AssertOutput("on start")
-	assert.Equal(t, outputs.Text("bar"), out)
+	assert.Equal(t, outputs.Text("bar").Segments(), out)
 	tester.AssertNoOutput("after the first output")
 
 	tester = testModule.NewOutputTester(t, Once("this-is-not-a-valid-command", "foo"))

--- a/outputs/outputs.go
+++ b/outputs/outputs.go
@@ -26,9 +26,17 @@ import (
 // bar output from it.
 type TemplateFunc func(interface{}) bar.Output
 
+// empty represents an empty output.
+type empty struct{}
+
+// Segments implements bar.Output for empty by returning an empty list.
+func (e empty) Segments() []bar.Segment {
+	return []bar.Segment{}
+}
+
 // Empty constructs an empty output, which will hide a module from the bar.
 func Empty() bar.Output {
-	return bar.Output{}
+	return empty{}
 }
 
 // Errorf constructs a bar output that indicates an error,
@@ -39,122 +47,39 @@ func Errorf(format string, args ...interface{}) bar.Output {
 
 // Error constructs a bar output that indicates an error.
 func Error(e error) bar.Output {
-	return bar.Output{bar.NewSegment(e.Error()).
+	return bar.NewSegment(e.Error()).
 		ShortText("Error").
-		Urgent(true),
-	}
+		Urgent(true)
 }
 
 // Textf constructs simple text output from a format string and arguments.
-func Textf(format string, args ...interface{}) bar.Output {
+func Textf(format string, args ...interface{}) bar.Segment {
 	return Text(fmt.Sprintf(format, args...))
 }
 
 //Text constructs a simple text output from the given string.
-func Text(text string) bar.Output {
-	return bar.Output{bar.NewSegment(text)}
+func Text(text string) bar.Segment {
+	return bar.NewSegment(text)
 }
 
 // PangoUnsafe constructs a bar output from existing pango markup.
 // This function does not perform any escaping.
-func PangoUnsafe(markup string) bar.Output {
-	return bar.Output{bar.NewSegment(markup).Markup(bar.MarkupPango)}
+func PangoUnsafe(markup string) bar.Segment {
+	return bar.NewSegment(markup).Markup(bar.MarkupPango)
 }
 
 // Pango constructs a bar output from a list of things.
-func Pango(things ...interface{}) bar.Output {
+func Pango(things ...interface{}) bar.Segment {
 	// The extra span tag will be collapsed if no attributes were added.
 	return PangoUnsafe(pango.Span(things...).Pango())
 }
 
-// Composite represents a "composite" bar output that collects compositeple
-// outputs and assigns each output a different "instance" name so that
-// click handlers can know what part of the output was clicked.
-type Composite interface {
-	// Add appends a named output segment to the composite bar output
-	// and returns it for chaining.
-	Add(string, bar.Output) Composite
-
-	// AddPango appends a named pango output segment to the composite
-	// bar output and returns it for chaining.
-	AddPango(instance string, things ...interface{}) Composite
-
-	// AddTextf appends a named text output segment with formatting
-	// to the composite bar output and returns it for chaining.
-	AddTextf(instance string, format string, args ...interface{}) Composite
-
-	// AddText appends a named text output segment to the composite
-	// bar output and returns it for chaining.
-	AddText(instance string, text string) Composite
-
-	// KeepSeparators sets whether inter-segment separators are removed.
-	// By default, inter-segment separators are removed when Build is called,
-	// but that behaviour can be overridden by calling KeepSeparators(true).
-	KeepSeparators(bool) Composite
-
-	// Build returns the built bar.Output with each segment's instance set
-	// to the appropriate value.
-	Build() bar.Output
-}
-
-type composite struct {
-	out        bar.Output
-	separators bool
-}
-
-func (c *composite) Add(instance string, output bar.Output) Composite {
-	for _, segment := range output {
-		segment.Instance(instance)
-		c.out = append(c.out, segment)
+// Group merges several outputs into a single SegmentGroup, to facilitate
+// easier manipulation of output properties (e.g. colour, urgency).
+func Group(outputs ...bar.Output) bar.SegmentGroup {
+	out := []bar.Segment{}
+	for _, o := range outputs {
+		out = append(out, o.Segments()...)
 	}
-	return c
-}
-
-func (c *composite) AddPango(instance string, things ...interface{}) Composite {
-	return c.addOne(instance, Pango(things...))
-}
-
-func (c *composite) AddTextf(instance string, format string, things ...interface{}) Composite {
-	return c.addOne(instance, Textf(format, things...))
-}
-
-func (c *composite) AddText(instance string, text string) Composite {
-	return c.addOne(instance, Text(text))
-}
-
-func (c *composite) KeepSeparators(separators bool) Composite {
-	c.separators = separators
-	return c
-}
-
-func (c *composite) Build() bar.Output {
-	if c.separators {
-		return c.out
-	}
-	for idx, segment := range c.out {
-		if idx+1 == len(c.out) {
-			continue
-		}
-		if _, ok := segment["separator"]; ok {
-			continue
-		}
-		segment.SeparatorWidth(0)
-		segment.Separator(false)
-	}
-	return c.out
-}
-
-// addOne adds the first (and only) element of the bar.Output after
-// setting its instance and returns the composite output for chaining.
-func (c *composite) addOne(instance string, output bar.Output) Composite {
-	segment := output[0]
-	segment.Instance(instance)
-	c.out = append(c.out, segment)
-	return c
-}
-
-// Multi creates an empty composite output, to which named segments
-// can be added.
-func Multi() Composite {
-	return &composite{}
+	return bar.SegmentGroup(out)
 }

--- a/testing/module/module.go
+++ b/testing/module/module.go
@@ -174,13 +174,13 @@ func (o *OutputTester) AssertNoOutput(message string) {
 }
 
 // AssertOutput asserts that the output channel was updated and returns the output.
-func (o *OutputTester) AssertOutput(message string) bar.Output {
+func (o *OutputTester) AssertOutput(message string) []bar.Segment {
 	select {
 	case out := <-o.outs:
-		return out
+		return out.Segments()
 	case <-time.After(positiveTimeout):
 		assert.Fail(o, "expected an update", message)
-		return bar.Output{}
+		return nil
 	}
 }
 

--- a/testing/module/module_test.go
+++ b/testing/module/module_test.go
@@ -212,7 +212,8 @@ func TestOutputTester(t *testing.T) {
 	testOut := outputs.Text("test")
 	m.Output(testOut)
 	actualOut := o.AssertOutput("has output")
-	assert.Equal(t, testOut, actualOut, "output passed through")
+	assert.Equal(t, testOut.Segments(), actualOut,
+		"output passed through")
 	m.Output(outputs.Empty())
 	o.AssertEmpty("on empty output")
 
@@ -227,7 +228,8 @@ func TestOutputTester(t *testing.T) {
 	testOut = outputs.Text("4")
 	m.Output(testOut)
 	actualOut = o.AssertOutput("has output")
-	assert.Equal(t, testOut, actualOut, "drain removes previous outputs")
+	assert.Equal(t, testOut.Segments(), actualOut,
+		"drain removes previous outputs")
 
 	fakeT := &testing.T{}
 	m = New(fakeT)


### PR DESCRIPTION
- Make bar.Output an interface that returns a list of segments.
- Implement bar.Output for a single segment by wrapping it in a list.
- Rename the previous bar.Output to SegmentGroup, and implement bar.Output for it.
- Remove outputs.Multi()/outputs.composite in favour of SegmentGroup.

This simplifies construction of outputs in two ways:
- `outputs.Multi().AddTextf(...).AddPango(...).Build()` becomes `outputs.Group(Textf(...), Pango(...))`
- outputs.Text/outputs.Pango return Segments, so `outputs.Text(...).Urgent(true)` still works,
  but now that Segment implements bar.Output it doesn't need to be wrapped in `bar.Output{...}`.