### PR TITLE
Run tests in parallel

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -2,23 +2,20 @@
 
 # From https://github.com/codecov/example-go#caveat-multiple-files
 set -e
-echo "" > coverage.txt
+mkdir profiles/
 
 # Run tests with coverage for all barista packages
-for d in $(go list ./... | grep -v barista/samples); do
-	go test -coverprofile=profile.out -race -covermode=atomic $d
-	if [ -f profile.out ]; then
-		cat profile.out >> coverage.txt
-		rm profile.out
-	fi
-done
+go list ./... \
+| grep -v barista/samples \
+| tac \
+| xargs -n1 -P4 -IPKG sh -c \
+'go test -coverprofile=profiles/$(echo "PKG" | sed "s|/|_|g").out -race -covermode=atomic "PKG"'
 
 # Debug log tests need the build tag, otherwise the nop versions will be used.
-go test -tags debuglog -coverprofile=profile.out -race -covermode=atomic ./logging
-if [ -f profile.out ]; then
-	cat profile.out >> coverage.txt
-	rm profile.out
-fi
+go test -tags debuglog -coverprofile=profiles/logging_real.out -race -covermode=atomic ./logging
+
+# Merge all code coverage reports.
+cat profiles/*.out > coverage.txt
 
 # Run tests only for samples.
 # This is just to make sure that all samples compile.


### PR DESCRIPTION
This significantly reduces the total test time because a lot of sleeps are now in parallel instead of sequential. (Especially mockio and timing, which have almost 30 seconds of sleep between them)