### PR TITLE
Apixu weather provider

### DIFF
--- a/modules/weather/apixu/apixu.go
+++ b/modules/weather/apixu/apixu.go
@@ -43,20 +43,14 @@ type Provider string
 // apixuWeather represents an Apixu json response.
 type apixuWeather struct {
 	Location struct {
-		Name           string  `json:"name"`
-		Region         string  `json:"region"`
-		Country        string  `json:"country"`
-		Lat            float64 `json:"lat"`
-		Lon            float64 `json:"lon"`
-		TzID           string  `json:"tz_id"`
-		LocaltimeEpoch int64   `json:"localtime_epoch"`
-		Localtime      string  `json:"localtime"`
+		Name    string `json:"name"`
+		Region  string `json:"region"`
+		Country string `json:"country"`
 	} `json:"location"`
 
 	Current struct {
 		Condition struct {
 			Text string `json:"text"`
-			Icon string `json:"icon"`
 			// Code is a code for describing weather (see https://www.apixu.com/doc/weather-conditions.aspx)
 			Code int `json:"code"`
 		} `json:"condition"`
@@ -64,41 +58,19 @@ type apixuWeather struct {
 		LastUpdated      string `json:"last_updated"`
 		LastUpdatedEpoch int64  `json:"last_updated_epoch"`
 
-		TempC float64 `json:"temp_c"`
 		TempF float64 `json:"temp_f"`
-
-		FeelsLikeC float64 `json:"feelslike_c"`
-		FeelsLikeF float64 `json:"feelslike_f"`
 
 		WindMPH    float64 `json:"wind_mph"`
 		WindKPH    float64 `json:"wind_kph"`
 		WindDegree int     `json:"wind_degree"`
-		WindDir    string  `json:"wind_dir"`
-
-		// IsDay is day (1) or night (0)
-		IsDay int `json:"is_day"`
 
 		// PressureMB is pressure in millibars
 		PressureMB float64 `json:"pressure_mb"`
-		// PressureIN is pressure in inches
-		PressureIN float64 `json:"pressure_in"`
-
-		// PrecipMM is precipitation in millimeters
-		PrecipMM float64 `json:"precip_mm"`
-		// PrecipIN is precipitation in inches
-		PrecipIN float64 `json:"precip_in"`
 
 		Humidity int `json:"humidity"`
 
 		// Cloud is cloud cover as percentage
 		Cloud int `json:"cloud"`
-
-		// VisKM is visibility is kilometers
-		VisKM float64 `json:"vis_km"`
-		// VisMiles is visibility is miles
-		VisMiles float64 `json:"vis_miles"`
-
-		UV float64 `json:"uv"`
 	} `json:"current"`
 }
 

--- a/modules/weather/apixu/apixu.go
+++ b/modules/weather/apixu/apixu.go
@@ -171,7 +171,7 @@ func (apixuProvider Provider) GetWeather() (weather.Weather, error) {
 		CloudCover:  float64(a.Current.Cloud) / 100.0,
 		Updated:     time.Unix(a.Current.LastUpdatedEpoch, 0),
 		Wind: weather.Wind{
-			Speed:     unit.Speed(a.Current.WindKPH) * unit.MetersPerSecond,
+			Speed:     unit.Speed(a.Current.WindKPH) * unit.KilometersPerHour,
 			Direction: weather.Direction(a.Current.WindDegree),
 		},
 		Attribution: "Apixu",

--- a/modules/weather/apixu/apixu.go
+++ b/modules/weather/apixu/apixu.go
@@ -1,0 +1,179 @@
+package apixu // import "barista.run/modules/weather/apixu"
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"barista.run/modules/weather"
+
+	"github.com/martinlindhe/unit"
+)
+
+// Config represents apixu API configuration (just the API key)
+// from which a weather.Provider can be built.
+type Config string
+
+// New creates a new Apixu API configuration.
+func New(apiKey string) Config {
+	return Config(apiKey)
+}
+
+// Query queries Apixu using zip code, lat/lon, city name, etc. (see https://www.apixu.com/doc/request.aspx)
+func (c Config) Query(q string) weather.Provider {
+	qp := url.Values{}
+	qp.Add("key", string(c))
+	qp.Add("q", q)
+	apixuURL := url.URL{
+		Scheme:   "http",
+		Host:     "api.apixu.com",
+		Path:     "/v1/current.json",
+		RawQuery: qp.Encode(),
+	}
+	return Provider(apixuURL.String())
+}
+
+// Provider wraps an Apixu API url so that
+// it can be used as a weather.Provider.
+type Provider string
+
+// apixuWeather represents an Apixu json response.
+type apixuWeather struct {
+	Location struct {
+		Name           string  `json:"name"`
+		Region         string  `json:"region"`
+		Country        string  `json:"country"`
+		Lat            float64 `json:"lat"`
+		Lon            float64 `json:"lon"`
+		TzID           string  `json:"tz_id"`
+		LocaltimeEpoch int64   `json:"localtime_epoch"`
+		Localtime      string  `json:"localtime"`
+	} `json:"location"`
+
+	Current struct {
+		Condition struct {
+			Text string `json:"text"`
+			Icon string `json:"icon"`
+			// Code is a code for describing weather (see https://www.apixu.com/doc/weather-conditions.aspx)
+			Code int `json:"code"`
+		} `json:"condition"`
+
+		LastUpdated      string `json:"last_updated"`
+		LastUpdatedEpoch int64  `json:"last_updated_epoch"`
+
+		TempC float64 `json:"temp_c"`
+		TempF float64 `json:"temp_f"`
+
+		FeelsLikeC float64 `json:"feelslike_c"`
+		FeelsLikeF float64 `json:"feelslike_f"`
+
+		WindMPH    float64 `json:"wind_mph"`
+		WindKPH    float64 `json:"wind_kph"`
+		WindDegree int     `json:"wind_degree"`
+		WindDir    string  `json:"wind_dir"`
+
+		// IsDay is day (1) or night (0)
+		IsDay int `json:"is_day"`
+
+		// PressureMB is pressure in millibars
+		PressureMB float64 `json:"pressure_mb"`
+		// PressureIN is pressure in inches
+		PressureIN float64 `json:"pressure_in"`
+
+		// PrecipMM is precipitation in millimeters
+		PrecipMM float64 `json:"precip_mm"`
+		// PrecipIN is precipitation in inches
+		PrecipIN float64 `json:"precip_in"`
+
+		Humidity int `json:"humidity"`
+
+		// Cloud is cloud cover as percentage
+		Cloud int `json:"cloud"`
+
+		// VisKM is visibility is kilometers
+		VisKM float64 `json:"vis_km"`
+		// VisMiles is visibility is miles
+		VisMiles float64 `json:"vis_miles"`
+
+		UV float64 `json:"uv"`
+	} `json:"current"`
+}
+
+func getCondition(apixuCondition int) weather.Condition {
+	switch apixuCondition {
+	case 1000:
+		return weather.Clear
+	case 1003:
+		return weather.PartlyCloudy
+	case 1006:
+		return weather.Cloudy
+	case 1009:
+		return weather.Overcast
+	case 1030:
+		return weather.Mist
+	case 1063, 1180, 1183, 1186, 1189, 1192,
+		1195, 1198, 1201, 1240, 1243, 1246:
+		return weather.Rain
+	case 1066, 1114, 1117, 1210, 1213, 1216, 1219,
+		1222, 1225, 1255, 1258, 1279, 1282:
+		return weather.Snow
+	case 1069, 1204, 1207, 1249, 1252:
+		return weather.Sleet
+	case 1072, 1150, 1153, 1168, 1171:
+		return weather.Drizzle
+	case 1087, 1273, 1276:
+		return weather.Thunderstorm
+	case 1135, 1147:
+		return weather.Fog
+	case 1237, 1261, 1264:
+		return weather.Hail
+	}
+
+	return weather.ConditionUnknown
+}
+
+// GetWeather gets weather information from Apixu.
+func (apixuProvider Provider) GetWeather() (weather.Weather, error) {
+	response, err := http.Get(string(apixuProvider))
+	if err != nil {
+		return weather.Weather{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == 401 {
+		return weather.Weather{}, fmt.Errorf("Invalid or missing API key")
+	}
+
+	if response.StatusCode == 403 {
+		return weather.Weather{}, fmt.Errorf("API key exceeded monthly quota")
+	}
+
+	a := apixuWeather{}
+	err = json.NewDecoder(response.Body).Decode(&a)
+	if err != nil {
+		return weather.Weather{}, err
+	}
+
+	return weather.Weather{
+		Location: strings.Join([]string{
+			a.Location.Name,
+			a.Location.Region,
+			a.Location.Country,
+		}, ", "),
+		Condition:   getCondition(a.Current.Condition.Code),
+		Description: a.Current.Condition.Text,
+		Temperature: unit.FromFahrenheit(a.Current.TempF),
+		Humidity:    float64(a.Current.Humidity) / 100.0,
+		Pressure:    unit.Pressure(a.Current.PressureMB) * unit.Millibar,
+		CloudCover:  float64(a.Current.Cloud) / 100.0,
+		Updated:     time.Unix(a.Current.LastUpdatedEpoch, 0),
+		Wind: weather.Wind{
+			Speed:     unit.Speed(a.Current.WindKPH) * unit.MetersPerSecond,
+			Direction: weather.Direction(a.Current.WindDegree),
+		},
+		Attribution: "Apixu",
+	}, nil
+}

--- a/modules/weather/apixu/apixu.go
+++ b/modules/weather/apixu/apixu.go
@@ -61,7 +61,6 @@ type apixuWeather struct {
 		TempF float64 `json:"temp_f"`
 
 		WindMPH    float64 `json:"wind_mph"`
-		WindKPH    float64 `json:"wind_kph"`
 		WindDegree int     `json:"wind_degree"`
 
 		// PressureMB is pressure in millibars
@@ -143,7 +142,7 @@ func (apixuProvider Provider) GetWeather() (weather.Weather, error) {
 		CloudCover:  float64(a.Current.Cloud) / 100.0,
 		Updated:     time.Unix(a.Current.LastUpdatedEpoch, 0),
 		Wind: weather.Wind{
-			Speed:     unit.Speed(a.Current.WindKPH) * unit.KilometersPerHour,
+			Speed:     unit.Speed(a.Current.WindMPH) * unit.MilesPerHour,
 			Direction: weather.Direction(a.Current.WindDegree),
 		},
 		Attribution: "Apixu",

--- a/modules/weather/apixu/apixu.go
+++ b/modules/weather/apixu/apixu.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package apixu // import "barista.run/modules/weather/apixu"
 
 import (

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -138,7 +138,7 @@ func TestProviderBuilder(t *testing.T) {
 
 func TestLive(t *testing.T) {
 	cron.Test(t, func() error {
-		wthr, err := New(os.Getenv("APIXU_API_KEY")).
+		wthr, err := New(os.Getenv("WEATHER_APIXU_API_KEY")).
 			Query("29617").
 			GetWeather()
 		if err != nil {

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -34,7 +34,7 @@ func TestGood(t *testing.T) {
 		Pressure:    1016.0 * unit.Millibar,
 		Temperature: unit.FromFahrenheit(48.0),
 		Wind: weather.Wind{
-			Speed:     unit.Speed(19.1) * unit.MetersPerSecond,
+			Speed:     unit.Speed(19.1) * unit.KilometersPerHour,
 			Direction: weather.Direction(40),
 		},
 		CloudCover:  1.0,

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -34,7 +34,7 @@ func TestGood(t *testing.T) {
 		Pressure:    1016.0 * unit.Millibar,
 		Temperature: unit.FromFahrenheit(48.0),
 		Wind: weather.Wind{
-			Speed:     unit.Speed(19.1) * unit.KilometersPerHour,
+			Speed:     unit.Speed(11.9) * unit.MilesPerHour,
 			Direction: weather.Direction(40),
 		},
 		CloudCover:  1.0,

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package apixu
 
 import (

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -1,0 +1,131 @@
+package apixu
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"barista.run/modules/weather"
+	"barista.run/testing/cron"
+	testServer "barista.run/testing/httpserver"
+
+	"github.com/martinlindhe/unit"
+	"github.com/stretchr/testify/require"
+)
+
+var ts *httptest.Server
+
+func TestMain(m *testing.M) {
+	ts = testServer.New()
+	defer ts.Close()
+	os.Exit(m.Run())
+}
+
+func TestGood(t *testing.T) {
+	wthr, err := Provider(ts.URL + "/static/good.json").GetWeather()
+	require.NoError(t, err)
+	require.NotNil(t, wthr)
+	require.Equal(t, weather.Weather{
+		Location:    "Greenville, South Carolina, USA",
+		Condition:   weather.Rain,
+		Description: "Light rain",
+		Humidity:    0.96,
+		Pressure:    1016.0 * unit.Millibar,
+		Temperature: unit.FromFahrenheit(48.0),
+		Wind: weather.Wind{
+			Speed:     unit.Speed(19.1) * unit.MetersPerSecond,
+			Direction: weather.Direction(40),
+		},
+		CloudCover:  1.0,
+		Updated:     time.Unix(1544845514, 0),
+		Attribution: "Apixu",
+	}, wthr)
+}
+
+func TestErrors(t *testing.T) {
+	_, err := Provider(ts.URL + "/code/400").GetWeather()
+	require.Error(t, err, "bad request")
+
+	_, err = Provider(ts.URL + "/code/401").GetWeather()
+	require.Error(t, err, "authentication error")
+
+	_, err = Provider(ts.URL + "/code/403").GetWeather()
+	require.Error(t, err, "API key exceeded monthly quota")
+}
+
+func TestConditions(t *testing.T) {
+	for _, tc := range []struct {
+		apixuCondition string
+		description    string
+		expected       weather.Condition
+	}{
+		{"1000", "Sunny", weather.Clear},
+		{"1003", "Partly cloudy", weather.PartlyCloudy},
+		{"1006", "Cloudy", weather.Cloudy},
+		{"1009", "Overcast", weather.Overcast},
+		{"1030", "Mist", weather.Mist},
+		{"1063", "Patchy rain possible", weather.Rain},
+		{"1066", "Patchy snow possible", weather.Snow},
+		{"1069", "Patchy sleet possible", weather.Sleet},
+		{"1072", "Patchy freezing drizzle possible", weather.Drizzle},
+		{"1087", "Thundery outbreaks possible", weather.Thunderstorm},
+		{"1114", "Blowing snow", weather.Snow},
+		{"1117", "Blizzard", weather.Snow},
+		{"1135", "Fog", weather.Fog},
+		{"1147", "Freezing fog", weather.Fog},
+		{"1150", "Patchy light drizzle", weather.Drizzle},
+		{"1153", "Light drizzle", weather.Drizzle},
+		{"1168", "Freezing drizzle", weather.Drizzle},
+		{"1171", "Heavy freezing drizzle", weather.Drizzle},
+		{"1180", "Patchy light rain", weather.Rain},
+		{"1183", "Light rain", weather.Rain},
+		{"1186", "Moderate rain at times", weather.Rain},
+		{"1189", "Moderate rain", weather.Rain},
+		{"1192", "Heavy rain at times", weather.Rain},
+		{"1195", "Heavy rain", weather.Rain},
+		{"1198", "Light freezing rain", weather.Rain},
+		{"1201", "Moderate or heavy freezing rain", weather.Rain},
+		{"1204", "Light sleet", weather.Sleet},
+		{"1207", "Moderate or heavy sleet", weather.Sleet},
+		{"1210", "Patchy light snow", weather.Snow},
+		{"1213", "Light snow", weather.Snow},
+		{"1216", "Patchy moderate snow", weather.Snow},
+		{"1219", "Moderate snow", weather.Snow},
+		{"1222", "Patchy heavy snow", weather.Snow},
+		{"1225", "Heavy snow", weather.Snow},
+		{"1237", "Ice pellets", weather.Hail},
+		{"1240", "Light rain shower", weather.Rain},
+		{"1243", "Moderate or heavy rain shower", weather.Rain},
+		{"1246", "Torrential rain shower", weather.Rain},
+		{"1249", "Light sleet showers", weather.Sleet},
+		{"1252", "Moderate or heavy sleet showers", weather.Sleet},
+		{"1255", "Light snow showers", weather.Snow},
+		{"1258", "Moderate or heavy snow showers", weather.Snow},
+		{"1261", "Light showers of ice pellets", weather.Hail},
+		{"1264", "Moderate or heavy showers of ice pellets", weather.Hail},
+		{"1273", "Patchy light rain with thunder", weather.Thunderstorm},
+		{"1276", "Moderate or heavy rain with thunder", weather.Thunderstorm},
+		{"1279", "Patchy light snow with thunder", weather.Snow},
+		{"1282", "Moderate or heavy snow with thunder", weather.Snow},
+		// Unknown condition.
+		{"0", "unknown", weather.ConditionUnknown},
+	} {
+		wthr, _ := Provider(ts.URL + "/tpl/conditions.json?code=" + tc.apixuCondition).GetWeather()
+		require.Equal(t, tc.expected, wthr.Condition,
+			"Apixu %s (%s)", tc.description, tc.apixuCondition)
+	}
+}
+
+func TestLive(t *testing.T) {
+	cron.Test(t, func() error {
+		wthr, err := New(os.Getenv("APIXU_API_KEY")).
+			Query("29617").
+			GetWeather()
+		if err != nil {
+			return err
+		}
+		require.NotNil(t, wthr)
+		return nil
+	})
+}

--- a/modules/weather/apixu/apixu_test.go
+++ b/modules/weather/apixu/apixu_test.go
@@ -117,6 +117,25 @@ func TestConditions(t *testing.T) {
 	}
 }
 
+func TestProviderBuilder(t *testing.T) {
+	for _, tc := range []struct {
+		expected    string
+		actual      weather.Provider
+		description string
+	}{
+		{"key=foo&q=29617", New("foo").Query("29617"), "Zip code"},
+		{"key=foo&q=Paris", New("foo").Query("Paris"), "City name"},
+		{"key=foo&q=145.77%2C-16.92", New("foo").Query("145.77,-16.92"), "Latitude and Longitude"},
+		{"key=foo&q=metar%3AEGLL", New("foo").Query("metar:EGLL"), "METAR"},
+		{"key=foo&q=iata%3ADXB", New("foo").Query("iata:DXB"), "IATA"},
+		{"key=foo&q=100.0.0.1", New("foo").Query("100.0.0.1"), "IP lookup"},
+		{"key=foo&q=auto%3Aip", New("foo").Query("auto:ip"), "Auto IP lookup"},
+	} {
+		expected := "http://api.apixu.com/v1/current.json?" + tc.expected
+		require.Equal(t, expected, string(tc.actual.(Provider)), tc.description)
+	}
+}
+
 func TestLive(t *testing.T) {
 	cron.Test(t, func() error {
 		wthr, err := New(os.Getenv("APIXU_API_KEY")).

--- a/modules/weather/apixu/testdata/conditions.json.tpl
+++ b/modules/weather/apixu/testdata/conditions.json.tpl
@@ -1,0 +1,39 @@
+{
+    "location": {
+        "name": "Greenville",
+        "region": "South Carolina",
+        "country": "USA",
+        "lat": -16.92,
+        "lon": 145.77,
+        "tz_id": "America/New_York",
+        "localtime_epoch": 1544846121,
+        "localtime": "2018-12-14 22:55"
+    },
+    "current": {
+        "last_updated_epoch": 1544845514,
+        "last_updated": "2018-12-14 22:45",
+        "temp_c": 8.9,
+        "temp_f": 48.0,
+        "is_day": 0,
+        "condition": {
+            "text": "{{.text}}",
+            "icon": "//cdn.apixu.com/weather/64x64/night/296.png",
+            "code": {{.code}}
+        },
+        "wind_mph": 11.9,
+        "wind_kph": 19.1,
+        "wind_degree": 40,
+        "wind_dir": "NE",
+        "pressure_mb": 1016.0,
+        "pressure_in": 30.5,
+        "precip_mm": 1.0,
+        "precip_in": 0.04,
+        "humidity": 96,
+        "cloud": 100,
+        "feelslike_c": 6.1,
+        "feelslike_f": 42.9,
+        "vis_km": 4.8,
+        "vis_miles": 2.0,
+        "uv": 2.0
+    }
+}

--- a/modules/weather/apixu/testdata/good.json
+++ b/modules/weather/apixu/testdata/good.json
@@ -1,0 +1,39 @@
+{
+    "location": {
+        "name": "Greenville",
+        "region": "South Carolina",
+        "country": "USA",
+        "lat": -16.92,
+        "lon": 145.77,
+        "tz_id": "America/New_York",
+        "localtime_epoch": 1544846121,
+        "localtime": "2018-12-14 22:55"
+    },
+    "current": {
+        "last_updated_epoch": 1544845514,
+        "last_updated": "2018-12-14 22:45",
+        "temp_c": 8.9,
+        "temp_f": 48.0,
+        "is_day": 0,
+        "condition": {
+            "text": "Light rain",
+            "icon": "//cdn.apixu.com/weather/64x64/night/296.png",
+            "code": 1183
+        },
+        "wind_mph": 11.9,
+        "wind_kph": 19.1,
+        "wind_degree": 40,
+        "wind_dir": "NE",
+        "pressure_mb": 1016.0,
+        "pressure_in": 30.5,
+        "precip_mm": 1.0,
+        "precip_in": 0.04,
+        "humidity": 96,
+        "cloud": 100,
+        "feelslike_c": 6.1,
+        "feelslike_f": 42.9,
+        "vis_km": 4.8,
+        "vis_miles": 2.0,
+        "uv": 2.0
+    }
+}


### PR DESCRIPTION
Implementing Apixu weather provider.  @soumya92 I tried to mimic what you're doing with the current weather providers, both in the module and test code.  I'll test implementing this on my actual bar tomorrow.

Usage is fairly simple:

```golang
apixu.New("API_KEY").Query("ZIP_CODE").GetWeather()
```

`Query()` accepts anything that the `q` param accepts here:  https://www.apixu.com/doc/request.aspx