### PR TITLE
Bluetooth module

### DIFF
--- a/modules/bluetooth/adapter.go
+++ b/modules/bluetooth/adapter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package bluetooth provides modules for watching the status of Bluetooth adapters.
+// Package bluetooth provides modules for watching the status of Bluetooth adapters and devices.
 package bluetooth // import "barista.run/modules/bluetooth"
 
 import (
@@ -21,8 +21,8 @@ import (
 	"barista.run/base/watchers/dbus"
 )
 
-// Module represents a Bluetooth bar module.
-type Module struct {
+// AdapterModule represents a Bluetooth bar module.
+type AdapterModule struct {
 	adapter    string
 	outputFunc value.Value
 }
@@ -39,24 +39,23 @@ type AdapterInfo struct {
 }
 
 // DefaultAdapter constructs an instance of the bluetooth module using the first adapter ("hci0").
-func DefaultAdapter() *Module {
+func DefaultAdapter() *AdapterModule {
 	return Adapter("hci0")
 }
 
 // Adapter constructs an instance of the bluetooth module with the provided device name (ex. "hci1").
-func Adapter(name string) *Module {
-	bt := &Module{adapter: name}
-	return bt
+func Adapter(name string) *AdapterModule {
+	return &AdapterModule{adapter: name}
 }
 
 // Output configures a module to display the output of a user-defined function.
-func (bt *Module) Output(outputFunc func(AdapterInfo) bar.Output) *Module {
+func (bt *AdapterModule) Output(outputFunc func(AdapterInfo) bar.Output) *AdapterModule {
 	bt.outputFunc.Set(outputFunc)
 	return bt
 }
 
 // Stream starts the module.
-func (bt *Module) Stream(sink bar.Sink) {
+func (bt *AdapterModule) Stream(sink bar.Sink) {
 	w := dbus.WatchProperties(
 		dbus.System,
 		"org.bluez",

--- a/modules/bluetooth/adapter.go
+++ b/modules/bluetooth/adapter.go
@@ -1,0 +1,100 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bluetooth provides modules for watching the status of Bluetooth adapters.
+package bluetooth // import "barista.run/modules/bluetooth"
+
+import (
+	"barista.run/bar"
+	"barista.run/base/value"
+	"barista.run/base/watchers/dbus"
+)
+
+// Module represents a Bluetooth bar module.
+type Module struct {
+	adapter    string
+	outputFunc value.Value
+}
+
+// AdapterInfo represents a Bluetooth adapters information.
+type AdapterInfo struct {
+	Name         string
+	Alias        string
+	Address      string
+	Discoverable bool
+	Pairable     bool
+	Powered      bool
+	Discovering  bool
+}
+
+// DefaultAdapter constructs an instance of the bluetooth module using the first adapter ("hci0").
+func DefaultAdapter() *Module {
+	return Adapter("hci0")
+}
+
+// Adapter constructs an instance of the bluetooth module with the provided device name (ex. "hci1").
+func Adapter(name string) *Module {
+	bt := &Module{adapter: name}
+	return bt
+}
+
+// Output configures a module to display the output of a user-defined function.
+func (bt *Module) Output(outputFunc func(AdapterInfo) bar.Output) *Module {
+	bt.outputFunc.Set(outputFunc)
+	return bt
+}
+
+// Stream starts the module.
+func (bt *Module) Stream(sink bar.Sink) {
+	w := dbus.WatchProperties(
+		dbus.System,
+		"org.bluez",
+		"/org/bluez/"+bt.adapter,
+		"org.bluez.Adapter1",
+	).
+		Add("Name", "Alias", "Address", "Discoverable", "Pairable", "Powered", "Discovering")
+	defer w.Unsubscribe()
+
+	outputFunc := bt.outputFunc.Get().(func(AdapterInfo) bar.Output)
+	nextOutputFunc, done := bt.outputFunc.Subscribe()
+	defer done()
+
+	info := getAdapterInfo(w)
+	for {
+		sink.Output(outputFunc(info))
+		select {
+		case <-w.Updates:
+			info = getAdapterInfo(w)
+		case <-nextOutputFunc:
+			outputFunc = bt.outputFunc.Get().(func(AdapterInfo) bar.Output)
+		}
+	}
+}
+
+func getAdapterInfo(w *dbus.PropertiesWatcher) AdapterInfo {
+	i := AdapterInfo{}
+	props := w.Get()
+
+	if name, ok := props["Name"].(string); ok {
+		i.Name = name
+	}
+	i.Alias, _ = props["Alias"].(string)
+	i.Address, _ = props["Address"].(string)
+	i.Discoverable, _ = props["Discoverable"].(bool)
+	i.Pairable, _ = props["Pairable"].(bool)
+	i.Powered, _ = props["Powered"].(bool)
+	i.Discovering, _ = props["Discovering"].(bool)
+
+	return i
+}

--- a/modules/bluetooth/adapter.go
+++ b/modules/bluetooth/adapter.go
@@ -38,6 +38,9 @@ type AdapterInfo struct {
 	Discovering  bool
 }
 
+// replaced in tests.
+var busType = dbus.System
+
 // DefaultAdapter constructs an instance of the bluetooth module using the first adapter ("hci0").
 func DefaultAdapter() *AdapterModule {
 	return Adapter("hci0")
@@ -57,7 +60,7 @@ func (bt *AdapterModule) Output(outputFunc func(AdapterInfo) bar.Output) *Adapte
 // Stream starts the module.
 func (bt *AdapterModule) Stream(sink bar.Sink) {
 	w := dbus.WatchProperties(
-		dbus.System,
+		busType,
 		"org.bluez",
 		"/org/bluez/"+bt.adapter,
 		"org.bluez.Adapter1",

--- a/modules/bluetooth/adapter_test.go
+++ b/modules/bluetooth/adapter_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bluetooth
+
+import (
+	"testing"
+
+	godbus "github.com/godbus/dbus"
+
+	"barista.run/bar"
+	"barista.run/base/watchers/dbus"
+	"barista.run/outputs"
+	testBar "barista.run/testing/bar"
+)
+
+func init() {
+	busType = dbus.Test
+}
+
+func TestAdapter(t *testing.T) {
+	testBar.New(t)
+	bus := dbus.SetupTestBus()
+	bluez := bus.RegisterService("org.bluez")
+
+	adapterName := "hci0"
+	adapterObjPath := godbus.ObjectPath("/org/bluez/" + adapterName)
+	adapter := bluez.Object(adapterObjPath, "org.bluez.Adapter1")
+	adapter.SetProperties(map[string]interface{}{
+		"Name":         "foo",
+		"Alias":        "foo alias",
+		"Address":      "28:C2:DD:8B:73:8C",
+		"Discoverable": false,
+		"Pairable":     true,
+		"Powered":      true,
+		"Discovering":  false,
+	}, dbus.SignalTypeNone)
+
+	btModule := Adapter(adapterName)
+	btModule.Output(func(i AdapterInfo) bar.Output {
+		state := "OFF"
+		if i.Powered {
+			state = "ON"
+		}
+		return outputs.Textf("%s: %s", i.Name, state)
+	})
+	testBar.Run(btModule)
+
+	testBar.LatestOutput().AssertText([]string{
+		"foo: ON",
+	})
+}

--- a/modules/bluetooth/device.go
+++ b/modules/bluetooth/device.go
@@ -1,0 +1,103 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bluetooth provides modules for watching the status of Bluetooth adapters and devices.
+package bluetooth // import "barista.run/modules/bluetooth"
+
+import (
+	"strings"
+
+	godbus "github.com/godbus/dbus"
+
+	"barista.run/bar"
+	"barista.run/base/value"
+	"barista.run/base/watchers/dbus"
+)
+
+// DeviceModule represents a Bluetooth devices bar module.
+type DeviceModule struct {
+	path       string
+	outputFunc value.Value
+}
+
+// DeviceInfo represents Bluetooth device information.
+type DeviceInfo struct {
+	Name      string
+	Alias     string
+	Address   string
+	Adapter   string
+	Paired    bool
+	Connected bool
+	Trusted   bool
+	Blocked   bool
+}
+
+// Device constructs a bluetooth device module instance for the given adapter and MAC address.
+func Device(adapter, mac string) *DeviceModule {
+	macPath := strings.Replace(mac, ":", "_", -1)
+	return &DeviceModule{path: "/org/bluez/" + adapter + "/dev_" + macPath}
+}
+
+// Output configures a module to display the output of a user-defined function.
+func (m *DeviceModule) Output(outputFunc func(DeviceInfo) bar.Output) *DeviceModule {
+	m.outputFunc.Set(outputFunc)
+	return m
+}
+
+// Stream starts the module.
+func (m *DeviceModule) Stream(sink bar.Sink) {
+	w := dbus.WatchProperties(
+		busType,
+		"org.bluez",
+		m.path,
+		"org.bluez.Device1",
+	).
+		Add("Name", "Alias", "Address", "Adapter", "Paired", "Connected", "Trusted", "Blocked")
+	defer w.Unsubscribe()
+
+	outputFunc := m.outputFunc.Get().(func(DeviceInfo) bar.Output)
+	nextOutputFunc, done := m.outputFunc.Subscribe()
+	defer done()
+
+	info := getDeviceInfo(w)
+	for {
+		sink.Output(outputFunc(info))
+		select {
+		case <-w.Updates:
+			info = getDeviceInfo(w)
+		case <-nextOutputFunc:
+			outputFunc = m.outputFunc.Get().(func(DeviceInfo) bar.Output)
+		}
+	}
+}
+
+func getDeviceInfo(w *dbus.PropertiesWatcher) DeviceInfo {
+	i := DeviceInfo{}
+	props := w.Get()
+
+	i.Name, _ = props["Name"].(string)
+	i.Alias, _ = props["Alias"].(string)
+	i.Address, _ = props["Address"].(string)
+
+	if adapter, ok := props["Adapter"].(godbus.ObjectPath); ok {
+		i.Adapter = string(adapter)
+	}
+
+	i.Paired, _ = props["Paired"].(bool)
+	i.Connected, _ = props["Connected"].(bool)
+	i.Trusted, _ = props["Trusted"].(bool)
+	i.Blocked, _ = props["Blocked"].(bool)
+
+	return i
+}

--- a/modules/bluetooth/device.go
+++ b/modules/bluetooth/device.go
@@ -45,7 +45,7 @@ type DeviceInfo struct {
 
 // Device constructs a bluetooth device module instance for the given adapter and MAC address.
 func Device(adapter, mac string) *DeviceModule {
-	macPath := strings.Replace(mac, ":", "_", -1)
+	macPath := strings.Replace(strings.ToUpper(mac), ":", "_", -1)
 	return &DeviceModule{path: "/org/bluez/" + adapter + "/dev_" + macPath}
 }
 

--- a/modules/bluetooth/device_test.go
+++ b/modules/bluetooth/device_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bluetooth
+
+import (
+	"strings"
+	"testing"
+
+	godbus "github.com/godbus/dbus"
+
+	"barista.run/bar"
+	"barista.run/base/watchers/dbus"
+	"barista.run/outputs"
+	testBar "barista.run/testing/bar"
+)
+
+func TestDevice(t *testing.T) {
+	testBar.New(t)
+	bus := dbus.SetupTestBus()
+	bluez := bus.RegisterService("org.bluez")
+
+	adapterName := "hci0"
+	deviceMac := "00:00:00:00:25:9F"
+	devicePath := "dev_" + strings.Replace(deviceMac, ":", "_", -1)
+	deviceObjPath := godbus.ObjectPath("/org/bluez/" + adapterName + "/" + devicePath)
+	device := bluez.Object(deviceObjPath, "org.bluez.Device1")
+	device.SetProperties(map[string]interface{}{
+		"Name":      "foo",
+		"Alias":     "foo alias",
+		"Address":   deviceMac,
+		"Paired":    true,
+		"Connected": true,
+		"Trusted":   true,
+		"Blocked":   false,
+	}, dbus.SignalTypeNone)
+
+	devModule := Device(adapterName, deviceMac)
+	devModule.Output(func(i DeviceInfo) bar.Output {
+		paired := "NO"
+		if i.Paired {
+			paired = "YES"
+		}
+		return outputs.Textf("%s: %s", i.Name, paired)
+	})
+	testBar.Run(devModule)
+
+	testBar.LatestOutput().AssertText([]string{
+		"foo: YES",
+	})
+}


### PR DESCRIPTION
@soumya92 Here's an initial stab at a BT module.  Usage:

```golang
import "barista.run/modules/bluetooth"

// DefaultAdapter() uses the commonly 'first' adapter of "hci0"
bluetooth.DefaultAdapter().Output(func(i bluetooth.AdapterInfo) bar.Output {
	state := "OFF"
	if i.Powered {
		state = "ON"
	}
	return pango.Textf("BT: %s", state)
})

// Or a named adapter:
bluetooth.Adapter("hci1").Output(...)
```

I'm trying to work out a module to watch device status, but I can't figure out how to construct the watcher, since I need the device 'path' (ie, `/org/bluez/hci0/dev_00_00_00_00_25_9F`) and I don't think your dbus properties watcher has the ability to get that info from an adapter watcher (unless I'm missing something).  Using the godbus package, I can get that info (as seen here https://gist.github.com/Oshuma/256024b1a6347c6a352b50c6ff94d307), but I'm not entirely sure what's the best approach to plug that into a module since that implementation is polling instead of watching for events.  Usage would look something like:

```golang
// BT device struct:
type DeviceInfo struct {
	Name      string
	Alias     string
	Address   string
	Adapter   string
	Paired    bool
	Connected bool
	Trusted   bool
	Blocked   bool
}

// In your bar file.
bluetooth.DefaultDevices().Output(func(devices []bluetooth.DeviceInfo) bar.Output {
	for i, info := devices {
		// info.Name, info.Paired, etc.
	}
}

bluetooth.Devices("hci1").Output(...)
```

Also, there's no tests yet.  I'll add those once everything is working properly.