### PR TITLE
Remove unnecessary repotoken flag from goveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - ./test.sh
 
 after_success:
-  - $HOME/gopath/bin/goveralls -coverprofile=c.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - $HOME/gopath/bin/goveralls -coverprofile=c.out -service=travis-ci
 
 before_deploy:
   - ./build.sh -tags prod -o sample-bar ./samples/sample-bar


### PR DESCRIPTION
Not needed for public repositories.

Currently provided as a secret in travis, preventing PRs from submitting coverage information. Removing the flag will allow PRs from other forks to report coverage as well, which is very important because coverage is a blocking check.