### PR TITLE
Use night icon for weather if before sunrise

### DIFF
--- a/samples/sample-bar/sample-bar.go
+++ b/samples/sample-bar/sample-bar.go
@@ -335,6 +335,8 @@ func main() {
 		case weather.Clear:
 			if !w.Sunset.IsZero() && time.Now().After(w.Sunset) {
 				iconName = "night"
+			} else if !w.Sunrise.IsZero() && time.Now().Before(w.Sunrise) {
+				iconName = "night"
 			} else {
 				iconName = "sunny"
 			}


### PR DESCRIPTION
This assumes that the sunrise and sunset times are for the current day. If that's true, then there are two times when we need night, between 00:00 and sunrise, and between sunset and 24:00.

Fixes #67