### PR TITLE
Fix battery discharging check

### DIFF
--- a/modules/battery/battery.go
+++ b/modules/battery/battery.go
@@ -105,7 +105,7 @@ func (i Info) RemainingTime() time.Duration {
 
 // Discharging returns true if the battery is being discharged.
 func (i Info) Discharging() bool {
-	return i.Status != Charging && i.Status != Full
+	return i.Status == Discharging
 }
 
 // PluggedIn returns true if the laptop is plugged in.

--- a/modules/battery/battery_test.go
+++ b/modules/battery/battery_test.go
@@ -87,6 +87,8 @@ func TestUnknownAndMissingStatus(t *testing.T) {
 
 	info = allBatteriesInfo()
 	require.Equal(Unknown, info.Status)
+
+	require.False(info.Discharging(), "Unknown battery is not discharging")
 }
 
 func TestGarbageFiles(t *testing.T) {


### PR DESCRIPTION
Check that status == discharging exactly, instead of trying to exclude other statuses.

Fixes #64