### PR TITLE
Fix golint on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ addons:
       - libasound2-dev
 
 install:
-  - go get golang.org/x/lint/golint
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
+  - go get -u golang.org/x/lint/golint
+  - go get -u golang.org/x/tools/cmd/cover
+  - go get -u github.com/mattn/goveralls
   - go get -t ./...
 
 script:


### PR DESCRIPTION
go has no versioning story, so we *must* update all dependencies. The -u flag should theoretically do that, but 🤷