### PR TITLE
Use go 1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 language: go
-go: "1.10"
+go: "1.13"
 go_import_path: barista.run
 sudo: false
 


### PR DESCRIPTION
Go has a support policy of less than a year, so we cannot use an older version of go an expect it to work.