### PR TITLE
Upgrade to netlink v1.1.0

### DIFF
--- a/base/watchers/netlink/nl.go
+++ b/base/watchers/netlink/nl.go
@@ -75,7 +75,7 @@ var newNlRequest = func(proto, flags int) nlRequest {
 }
 
 type nlReceiver interface {
-	Receive() ([]syscall.NetlinkMessage, error)
+	Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error)
 }
 
 var nlSubscribe = func(protocol int, groups ...uint) (nlReceiver, error) {
@@ -136,7 +136,7 @@ func nlListen() {
 		return
 	}
 	for {
-		msgs, err := s.Receive()
+		msgs, _, err := s.Receive()
 		if err != nil {
 			l.Log("nl Receive failed: %s", err)
 			continue

--- a/base/watchers/netlink/nl_test.go
+++ b/base/watchers/netlink/nl_test.go
@@ -28,12 +28,12 @@ type testNlSubscriber struct {
 	errorChan <-chan error
 }
 
-func (t *testNlSubscriber) Receive() ([]syscall.NetlinkMessage, error) {
+func (t *testNlSubscriber) Receive() ([]syscall.NetlinkMessage, *unix.SockaddrNetlink, error) {
 	select {
 	case m := <-t.msgChan:
-		return []syscall.NetlinkMessage{m}, nil
+		return []syscall.NetlinkMessage{m}, nil, nil
 	case e := <-t.errorChan:
-		return nil, e
+		return nil, nil, e
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,7 @@ require (
 	github.com/maximbaz/yubikey-touch-detector v0.0.0-20190725083449-25eabf6f1933
 	github.com/spf13/afero v1.2.2
 	github.com/stretchr/testify v1.4.0
-	github.com/vishvananda/netlink v1.0.0
-	github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f // indirect
+	github.com/vishvananda/netlink v1.1.0
 	github.com/zalando/go-keyring v0.0.0-20190913082157-62750a1ff80d
 	go.opencensus.io v0.22.1 // indirect
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,12 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f h1:nBX3nTcmxEtHSERBJaIo1Qa26VwRaopnZmfDQUXsF4I=
 github.com/vishvananda/netns v0.0.0-20190625233234-7109fa855b0f/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/zalando/go-keyring v0.0.0-20190913082157-62750a1ff80d h1:4A0ij77iFgd+mHJxzzTlpAZve9SrZ6fuksQr6NfoA/I=
 github.com/zalando/go-keyring v0.0.0-20190913082157-62750a1ff80d/go.mod h1:RaxNwUITJaHVdQ0VC7pELPZ3tOWn13nr0gZMZEhpVU0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -152,6 +156,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191104094858-e8c54fb511f6 h1:ZJUmhYTp8GbGC0ViZRc2U+MIYQ8xx9MscsdXnclfIhw=


### PR DESCRIPTION
1.1.0 is a backwards incompatible change from 1.0.0, so it broke anyone not using go.mod in their own project (or something).

This should get us buildable from master again. And fix #90 