### PR TITLE
add support for two more interface states

### DIFF
--- a/modules/netinfo/netinfo.go
+++ b/modules/netinfo/netinfo.go
@@ -43,6 +43,16 @@ func (s State) Enabled() bool {
 	return s.State > netlink.NotPresent
 }
 
+// Unknown returns true if a network interface is in Unknown state.
+func (s State) Unknown() bool {
+	return s.State == netlink.Unknown
+}
+
+// Gone returns true if a network interface just disappeared..
+func (s State) Gone() bool {
+	return s.State == netlink.Gone
+}
+
 // Module represents a netinfo bar module.
 type Module struct {
 	subscriber func() *netlink.Subscription


### PR DESCRIPTION
This adds two more interface states for netlink states that are not yet covered.