### PR TITLE
use https for connecting to api.openweathermap.org

### DIFF
--- a/modules/weather/openweathermap/openweathermap.go
+++ b/modules/weather/openweathermap/openweathermap.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ func (c Config) build(query [][2]string) weather.Provider {
 		qp.Add(value[0], value[1])
 	}
 	owmURL := url.URL{
-		Scheme:   "http",
+		Scheme:   "https",
 		Host:     "api.openweathermap.org",
 		Path:     "/data/2.5/weather",
 		RawQuery: qp.Encode(),

--- a/modules/weather/openweathermap/openweathermap_test.go
+++ b/modules/weather/openweathermap/openweathermap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ func TestProviderBuilder(t *testing.T) {
 		{"appid=foo&lat=10.000000&lon=40.000000", New("foo").Coords(10.0, 40.0), "Coords"},
 		{"appid=foo&zip=85719%2CUS", New("foo").Zipcode("85719", "US"), "Zipcode"},
 	} {
-		expected := "http://api.openweathermap.org/data/2.5/weather?" + tc.expected
+		expected := "https://api.openweathermap.org/data/2.5/weather?" + tc.expected
 		require.Equal(t, expected, string(tc.actual.(Provider)), tc.description)
 	}
 }


### PR DESCRIPTION
Historically openweathermap only provided `http` endpoints for their API. However, the API supports `https` for quite some time now, so it makes sense to switch. This one should be trivial ;).