### PR TITLE
add community modules section

### DIFF
--- a/index.md
+++ b/index.md
@@ -112,3 +112,9 @@ For more details and a complete example, see the guide to [writing a module](/do
 of integrating a third-party go package, see the
 [yubikey sample module](https://github.com/soumya92/barista/blob/master/samples/yubikey/yubikey.go).
 
+# Community Modules
+
+There are also other barista modules out there which are maintained by the community:
+
+- [martinohmann/barista-contrib](https://martinohmann.github.io/barista-contrib/):
+    A collection of other useful extensions and modules like keyboard, updates, dpms and ip.


### PR DESCRIPTION
As discussed in #148, this adds a community modules section to the docs which contains a link to the docs of https://github.com/martinohmann/barista-contrib (docs: https://martinohmann.github.io/barista-contrib/).

I hope you don't mind that I "stole" some of the snippets for displaying the module examples from your jekyll template and used it in my own so that it blends in nicely ;).

#148 can be closed afterwards I guess.