### PR TITLE
Use timerfd for real-time clock updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd
+	golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	google.golang.org/api v0.20.0
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f h1:mOhmO9WsBaJCNmaZHPtHs9wOcdqdKCjF6OPJlmDM3KI=
+golang.org/x/sys v0.0.0-20200509044756-6aff5f38e54f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/timing/internal/timerfd/nativeendian.go
+++ b/timing/internal/timerfd/nativeendian.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timerfd
+
+import (
+	"encoding/binary"
+	"unsafe"
+)
+
+var nativeEndian binary.ByteOrder
+
+func init() {
+	i := uint32(1)
+	b := (*[4]byte)(unsafe.Pointer(&i))
+	if b[0] == 1 {
+		nativeEndian = binary.LittleEndian
+	} else {
+		nativeEndian = binary.BigEndian
+	}
+}

--- a/timing/internal/timerfd/timerfd.go
+++ b/timing/internal/timerfd/timerfd.go
@@ -1,0 +1,102 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package timerfd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// ErrTimerfdCancelled is the error returned when timer is cancelled due to
+// discontinuous clock change. See man timerfd_settime for details.
+var ErrTimerfdCancelled = errors.New("Timerfd was cancelled due to discontinuous change")
+
+// Timerfd provides higher-level abstraction for Linux-specific timerfd timers.
+type Timerfd struct {
+	fd      *os.File
+	clockid int
+}
+
+func newTimerfd(clockid int) (*Timerfd, error) {
+	fd, err := unix.TimerfdCreate(clockid, unix.TFD_NONBLOCK|unix.TFD_CLOEXEC)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), "Timerfd")
+	return &Timerfd{fd: f, clockid: clockid}, nil
+}
+
+// Settime arms or disarms the timer. See man timerfd_settime for details.
+func (t *Timerfd) Settime(newValue *unix.ItimerSpec, oldValue *unix.ItimerSpec, absolute bool, cancelOnSet bool) error {
+	rawConn, err := t.fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var err2 error
+	err = rawConn.Control(func(fd uintptr) {
+		var flags int
+		if absolute {
+			flags |= unix.TFD_TIMER_ABSTIME
+		}
+		if cancelOnSet {
+			flags |= unix.TFD_TIMER_CANCEL_ON_SET
+		}
+		err2 = unix.TimerfdSettime(int(fd), flags, newValue, oldValue)
+	})
+	if err != nil {
+		return err
+	}
+	return err2
+}
+
+// Wait waits until timer expiration. See man timerfd_create for details.
+func (t *Timerfd) Wait() (expirations uint64, err error) {
+	var buf [8]byte
+
+	n, err := t.fd.Read(buf[:])
+	if err != nil {
+		if pe, ok := err.(*os.PathError); ok {
+			err = pe.Err
+		}
+		if err == unix.ECANCELED {
+			err = ErrTimerfdCancelled
+		}
+		return 0, err
+	}
+	if n != 8 {
+		panic(fmt.Sprintf("Timerfd returned %d bytes (expected 8)", n))
+	}
+	return nativeEndian.Uint64(buf[:]), nil
+}
+
+// GetClockid returns the clock id that this timerfd uses.
+func (t *Timerfd) GetClockid() int {
+	return t.clockid
+}
+
+// Close closes the underlying timerfd descriptor.
+func (t *Timerfd) Close() error {
+	return t.fd.Close()
+}
+
+// NewRealtimeTimerfd returns a Timerfd backed by CLOCK_REALTIME.
+func NewRealtimeTimerfd() (*Timerfd, error) {
+	return newTimerfd(unix.CLOCK_REALTIME)
+}

--- a/timing/misc.go
+++ b/timing/misc.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timing
+
+import (
+	"time"
+)
+
+// nextAlignedExpiration calculates the next expiration time.
+// The expiration is first rounded to interval granularity, and then offset is added.
+//
+// For example, given interval 1h, and offset 15m, the expirations will happen at
+// :15 of every hour regardless of the initial time.
+func nextAlignedExpiration(initial time.Time, interval time.Duration, offset time.Duration) time.Time {
+	next := initial.Truncate(interval).Add(offset)
+	if !next.After(initial) {
+		next = next.Add(interval)
+	}
+	if !next.After(initial) {
+		panic("nextAlignedExpiration: bug: !next.After(initial)")
+	}
+	return next
+}

--- a/timing/scheduler.go
+++ b/timing/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc.
+// Copyright 2020 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,42 +33,34 @@ type Scheduler struct {
 	// A channel that receives an empty struct for each tick of the scheduler.
 	C <-chan struct{}
 
-	mu      sync.Mutex
-	timer   *time.Timer
-	ticker  *time.Ticker
-	quitter chan struct{}
-
 	notifyFn func()
 	waiting  int32 // basically bool, but we need atomics.
 
-	// For test mode
-	testModeID uint32
-	startTime  time.Time
-	interval   time.Duration
+	schedulerImpl schedulerImpl
 }
 
 var (
 	// A set of channels to be closed by timing.Resume.
 	// This allows schedulers to wait for resume, without
 	// requiring a reference to each created scheduler.
-	waiters  []chan struct{}
-	paused   = false
-	testMode = false
+	waiters []chan struct{}
+	paused  = false
 
 	mu sync.Mutex
 )
 
-// NewScheduler creates a new scheduler.
-func NewScheduler() *Scheduler {
+type schedulerImpl interface {
+	At(time.Time, func())
+	After(time.Duration, func())
+	Every(time.Duration, func())
+	EveryAlign(time.Duration, time.Duration, func())
+	Stop()
+	Close()
+}
+
+func newScheduler(impl schedulerImpl) *Scheduler {
 	s := new(Scheduler)
-	mu.Lock()
-	inTestMode := testMode
-	mu.Unlock()
-	if inTestMode {
-		triggersMu.Lock()
-		s.testModeID = testModeID
-		triggersMu.Unlock()
-	}
+	s.schedulerImpl = impl
 	s.notifyFn, s.C = notifier.New()
 	l.Register(s, "C")
 	return s
@@ -120,28 +112,16 @@ func (s *Scheduler) Tick() bool {
 // At sets the scheduler to trigger a specific time.
 // This will replace any pending triggers.
 func (s *Scheduler) At(when time.Time) *Scheduler {
-	if s.testModeID > 0 {
-		return s.testModeAt(when)
-	}
 	l.Fine("%s At(%v)", l.ID(s), when)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stop()
-	s.timer = time.AfterFunc(when.Sub(Now()), s.maybeTrigger)
+	s.schedulerImpl.At(when, s.maybeTrigger)
 	return s
 }
 
 // After sets the scheduler to trigger after a delay.
 // This will replace any pending triggers.
 func (s *Scheduler) After(delay time.Duration) *Scheduler {
-	if s.testModeID > 0 {
-		return s.testModeAfter(delay)
-	}
 	l.Fine("%s After(%v)", l.ID(s), delay)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stop()
-	s.timer = time.AfterFunc(delay, s.maybeTrigger)
+	s.schedulerImpl.After(delay, s.maybeTrigger)
 	return s
 }
 
@@ -151,46 +131,44 @@ func (s *Scheduler) Every(interval time.Duration) *Scheduler {
 	if interval <= 0 {
 		panic(errors.New("non-positive interval for Scheduler#Every"))
 	}
-	if s.testModeID > 0 {
-		return s.testModeEvery(interval)
-	}
 	l.Fine("%s Every(%v)", l.ID(s), interval)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stop()
-	s.quitter = make(chan struct{})
-	s.ticker = time.NewTicker(interval)
-	go func() {
-		s.mu.Lock()
-		ticker := s.ticker
-		quitter := s.quitter
-		s.mu.Unlock()
-		if ticker == nil || quitter == nil {
-			// Scheduler stopped before goroutine was started.
-			return
-		}
-		for {
-			select {
-			case <-ticker.C:
-				s.maybeTrigger()
-			case <-quitter:
-				return
-			}
-		}
-	}()
+	s.schedulerImpl.Every(interval, s.maybeTrigger)
+	return s
+}
+
+// EveryAlign sets the scheduler to trigger at an interval.
+//
+// Offset specifies the scheduler alignment. For example, if interval=1min,
+// and offset=11s, the timer will trigger every minute at exactly :11 seconds
+// of the underlying clock. This makes most sense for schedulers based on
+// the real time clock.
+// Usually offset should be zero. A clock that displays the time with minute
+// precision should probably update at :00 seconds, and
+// interval=1min and offset=0 do exactly that.
+//
+// This will replace any pending triggers.
+func (s *Scheduler) EveryAlign(interval time.Duration, offset time.Duration) *Scheduler {
+	if interval <= 0 {
+		panic(errors.New("non-positive interval for Scheduler#EveryAlign"))
+	}
+	if offset < 0 {
+		panic(errors.New("negative offset for Scheduler#EveryAlign"))
+	}
+	l.Fine("%s EveryAlign(%v, %v)", l.ID(s), interval, offset)
+	s.schedulerImpl.EveryAlign(interval, offset, s.maybeTrigger)
 	return s
 }
 
 // Stop cancels all further triggers for the scheduler.
 func (s *Scheduler) Stop() {
-	if s.testModeID > 0 {
-		s.testModeStop()
-		return
-	}
 	l.Fine("%s Stop", l.ID(s))
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.stop()
+	s.schedulerImpl.Stop()
+}
+
+// Close cleans up all resources allocated by the scheduler, if necessary.
+func (s *Scheduler) Close() {
+	l.Fine("%s Close", l.ID(s))
+	s.schedulerImpl.Close()
 }
 
 func (s *Scheduler) maybeTrigger() {
@@ -202,19 +180,4 @@ func (s *Scheduler) maybeTrigger() {
 			s.notifyFn()
 		}
 	})
-}
-
-func (s *Scheduler) stop() {
-	if s.timer != nil {
-		s.timer.Stop()
-		s.timer = nil
-	}
-	if s.ticker != nil {
-		s.ticker.Stop()
-		s.ticker = nil
-	}
-	if s.quitter != nil {
-		close(s.quitter)
-		s.quitter = nil
-	}
 }

--- a/timing/schedulerimpl_test.go
+++ b/timing/schedulerimpl_test.go
@@ -1,0 +1,160 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timing
+
+import (
+	"testing"
+	"time"
+)
+
+func testSchedulerImplementation(t *testing.T, create func() *Scheduler) {
+	if testing.Short() {
+		t.Skip("skipping scheduler tests that need real time passage in short mode.")
+	}
+
+	t.Run("At", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		begin := time.Now()
+		s.At(begin.Add(time.Second))
+
+		select {
+		case <-s.C:
+			if time.Now().Sub(begin) < time.Second {
+				t.Errorf("scheduler triggered too early begin=%v now=%v", begin, time.Now())
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("scheduler did not trigger")
+		}
+
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered twice!")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	t.Run("AtStop", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		begin := time.Now()
+		s.At(begin.Add(2 * time.Second))
+		time.Sleep(time.Second)
+		s.Stop()
+
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered even though stopped")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	t.Run("After", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		begin := time.Now()
+		s.After(time.Second)
+
+		select {
+		case <-s.C:
+			if time.Now().Sub(begin) < time.Second {
+				t.Errorf("scheduler triggered too early begin=%v now=%v", begin, time.Now())
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("scheduler did not trigger")
+		}
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered twice!")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	t.Run("AfterStop", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		s.After(2 * time.Second)
+		time.Sleep(time.Second)
+		s.Stop()
+
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered even though stopped")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	t.Run("Every", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		begin := time.Now()
+		s.Every(time.Second)
+
+		for i := 0; i < 2; i++ {
+			select {
+			case <-s.C:
+				if time.Now().Sub(begin) < time.Second*time.Duration(i+1) {
+					t.Errorf("scheduler triggered too early (tick %d) begin=%v now=%v", i, begin, time.Now())
+				}
+			case <-time.After(2 * time.Second):
+				t.Errorf("scheduler did not trigger (tick %d)", i)
+			}
+		}
+		s.Stop()
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered even though stopped")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	t.Run("EveryAlign", func(t *testing.T) {
+		s := create()
+		defer s.Close()
+
+		const interval = time.Second
+
+		now := time.Now()
+		time.Sleep(now.Add(interval).Truncate(interval).Add(interval / 2).Sub(now))
+		// sleep until next :00.500 second
+
+		s.EveryAlign(time.Second, time.Duration(0))
+
+		for i := 0; i < 2; i++ {
+			select {
+			case <-s.C:
+				now := time.Now()
+				// on my machine, the alignment precision is usually 0.1ms
+				if now.Sub(now.Truncate(interval)) > 10*time.Millisecond {
+					t.Errorf("trigger time was not aligned (tick %d) now=%v", i, now)
+				}
+			case <-time.After(2 * time.Second):
+				t.Errorf("scheduler did not trigger (tick %d)", i)
+			}
+		}
+		s.Stop()
+		select {
+		case <-s.C:
+			t.Error("scheduler triggered even though stopped")
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+}

--- a/timing/testmode_test.go
+++ b/timing/testmode_test.go
@@ -27,6 +27,7 @@ import (
 
 func TestTiming_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 
 	sch1 := NewScheduler()
 	sch2 := NewScheduler()
@@ -75,6 +76,7 @@ func TestTiming_TestMode(t *testing.T) {
 
 func TestRepeating_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 	sch1 := NewScheduler()
 	sch2 := NewScheduler()
 	now := Now()
@@ -102,6 +104,7 @@ func TestRepeating_TestMode(t *testing.T) {
 
 func TestRepeatingChange_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 	sch := NewScheduler()
 	now := Now()
 
@@ -119,6 +122,7 @@ func TestRepeatingChange_TestMode(t *testing.T) {
 
 func TestMultipleTriggers_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 	sch1 := NewScheduler()
 	sch2 := NewScheduler()
 	sch3 := NewScheduler()
@@ -141,6 +145,7 @@ func TestMultipleTriggers_TestMode(t *testing.T) {
 
 func TestAdvanceWithRepeated_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 
 	sch := NewScheduler()
 	sch.Every(time.Second)
@@ -173,6 +178,7 @@ func TestAdvanceWithRepeated_TestMode(t *testing.T) {
 
 func TestCoalescedUpdates_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 
 	sch := NewScheduler()
 	sch.Every(15 * time.Millisecond)
@@ -184,6 +190,7 @@ func TestCoalescedUpdates_TestMode(t *testing.T) {
 
 func TestPauseResume_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 
 	sch := NewScheduler()
 	start := Now()
@@ -224,6 +231,7 @@ func TestPauseResume_TestMode(t *testing.T) {
 
 func TestPastTriggers_TestMode(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 	sch := NewScheduler()
 	now := Now()
 	sch.After(-1 * time.Minute)
@@ -256,6 +264,7 @@ func TestPastTriggers_TestMode(t *testing.T) {
 
 func TestTestModeReset(t *testing.T) {
 	TestMode()
+	defer ExitTestMode()
 	sch1 := NewScheduler().Every(time.Second)
 
 	startTime := Now()

--- a/timing/time_scheduler.go
+++ b/timing/time_scheduler.go
@@ -1,0 +1,127 @@
+package timing
+
+import (
+	"sync"
+	"time"
+)
+
+var _ schedulerImpl = &timeScheduler{}
+
+// timeScheduler is a scheduler backed by "time" package.
+type timeScheduler struct {
+	mu      sync.Mutex
+	timer   *time.Timer
+	ticker  *time.Ticker
+	quitter chan struct{}
+}
+
+// NewScheduler creates a new scheduler.
+//
+// The scheduler is backed by "time" package. Its "At" implementation
+// is unreliable, as it's unable to take system suspend and time adjustments
+// into account.
+func NewScheduler() *Scheduler {
+	if testModeScheduler := maybeNewTestModeScheduler(); testModeScheduler != nil {
+		return newScheduler(testModeScheduler)
+	}
+	return newScheduler(&timeScheduler{})
+}
+
+// At implements the schedulerImpl interface.
+func (s *timeScheduler) At(when time.Time, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stop()
+	s.timer = time.AfterFunc(when.Sub(Now()), f)
+}
+
+// After implements the schedulerImpl interface.
+func (s *timeScheduler) After(delay time.Duration, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stop()
+	s.timer = time.AfterFunc(delay, f)
+}
+
+// Every implements the schedulerImpl interface.
+func (s *timeScheduler) Every(interval time.Duration, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stop()
+	s.quitter = make(chan struct{})
+	s.ticker = time.NewTicker(interval)
+	go func() {
+		s.mu.Lock()
+		ticker := s.ticker
+		quitter := s.quitter
+		s.mu.Unlock()
+		if ticker == nil || quitter == nil {
+			// Scheduler stopped before goroutine was started.
+			return
+		}
+		for {
+			select {
+			case <-ticker.C:
+				f()
+			case <-quitter:
+				return
+			}
+		}
+	}()
+}
+
+// EveryAlign implements the schedulerImpl interface.
+func (s *timeScheduler) EveryAlign(interval time.Duration, offset time.Duration, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stop()
+	quitter := make(chan struct{})
+	s.quitter = quitter
+	go func() {
+		var timer *time.Timer
+		for {
+			now := time.Now()
+			next := nextAlignedExpiration(now, interval, offset)
+			delay := next.Sub(now)
+			if timer == nil {
+				timer = time.NewTimer(delay)
+				defer timer.Stop()
+			} else {
+				timer.Reset(delay)
+			}
+			select {
+			case <-timer.C:
+				f()
+			case <-quitter:
+				return
+			}
+		}
+	}()
+}
+
+// Stop implements the schedulerImpl interface.
+func (s *timeScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stop()
+}
+
+// Close implements the schedulerImpl interface.
+func (s *timeScheduler) Close() {
+	s.Stop()
+}
+
+func (s *timeScheduler) stop() {
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+	if s.ticker != nil {
+		s.ticker.Stop()
+		s.ticker = nil
+	}
+	if s.quitter != nil {
+		close(s.quitter)
+		s.quitter = nil
+	}
+}

--- a/timing/time_scheduler_test.go
+++ b/timing/time_scheduler_test.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timing
+
+import (
+	"testing"
+)
+
+func TestTimeSchedulerImpl(t *testing.T) {
+	testSchedulerImplementation(t, NewScheduler)
+}

--- a/timing/timerfd_scheduler.go
+++ b/timing/timerfd_scheduler.go
@@ -1,0 +1,201 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package timing
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	l "barista.run/logging"
+	"barista.run/timing/internal/timerfd"
+)
+
+var _ schedulerImpl = &timerfdScheduler{}
+
+// timerfdScheduler represents a scheduler backed by system real-time clock.
+type timerfdScheduler struct {
+	mu       sync.Mutex
+	timerfd  *timerfd.Timerfd
+	interval time.Duration
+	offset   time.Duration
+	f        func()
+}
+
+// NewRealtimeScheduler creates a scheduler backed by system real-time clock.
+//
+// It properly handles system suspend (sleep mode) and time adjustments. For periodic timers,
+// it triggers immediately whenever time changes discontinuously. For one-shot timers
+// (At and After), it will fire immediately if the time is skipped over
+// the set trigger time, and will properly wait for it otherwise.
+//
+// This scheduler is only properly supported on Linux. On other systems,
+// plain scheduler based on "time" package is returned.
+//
+// In order to clean up resources associated with it,
+// remember to call Stop().
+func NewRealtimeScheduler() (*Scheduler, error) {
+	if testModeScheduler := maybeNewTestModeScheduler(); testModeScheduler != nil {
+		return newScheduler(testModeScheduler), nil
+	}
+
+	timerfd, err := timerfd.NewRealtimeTimerfd()
+	if err != nil {
+		return nil, err
+	}
+	impl := &timerfdScheduler{timerfd: timerfd}
+	go impl.loop()
+
+	return newScheduler(impl), nil
+}
+
+// At implements the schedulerImpl interface.
+func (s *timerfdScheduler) At(when time.Time, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// note for future: only valid for CLOCK_REALTIME
+	timespec, err := unix.TimeToTimespec(when)
+	if err != nil {
+		panic("TimeToTimespec failed: " + err.Error())
+	}
+
+	err = s.timerfd.Settime(&unix.ItimerSpec{
+		Value: timespec,
+	}, nil, true, false)
+	if err != nil {
+		panic("Settime failed: " + err.Error())
+	}
+
+	s.interval = 0
+	s.f = f
+}
+
+// After implements the schedulerImpl interface.
+func (s *timerfdScheduler) After(delay time.Duration, f func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := s.timerfd.Settime(&unix.ItimerSpec{
+		Value: unix.NsecToTimespec(delay.Nanoseconds()),
+	}, nil, false, false)
+	if err != nil {
+		panic("Settime failed: " + err.Error())
+	}
+
+	s.interval = 0
+	s.f = f
+}
+
+// Every implements the schedulerImpl interface.
+func (s *timerfdScheduler) Every(interval time.Duration, f func()) {
+	now := Now()
+	offset := now.Sub(now.Truncate(interval))
+	s.EveryAlign(interval, offset, f)
+}
+
+// EveryAlign implements the schedulerImpl interface.
+func (s *timerfdScheduler) EveryAlign(interval time.Duration, offset time.Duration, f func()) {
+	if interval <= 0 {
+		panic(errors.New("non-positive interval for RealtimeScheduler#Every"))
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.interval = interval
+	s.offset = offset - offset.Truncate(interval)
+	s.f = f
+
+	s.rearmPeriodicTimerLocked()
+}
+
+// Stop implements the schedulerImpl interface.
+func (s *timerfdScheduler) Stop() {
+	s.timerfd.Settime(&unix.ItimerSpec{}, nil, false, false)
+}
+
+// Close implements the schedulerImpl interface.
+func (s *timerfdScheduler) Close() {
+	s.timerfd.Close()
+}
+
+// rearmPeriodicTimerLocked panics when an error occurs,
+// because any errors are not handleable runtime failures,
+// but rather extreme conditions. See comments near panics below.
+func (s *timerfdScheduler) rearmPeriodicTimerLocked() {
+	if s.interval == 0 {
+		return
+	}
+
+	var currentTimespec unix.Timespec
+	if err := unix.ClockGettime(int32(s.timerfd.GetClockid()), &currentTimespec); err != nil {
+		// see man clock_gettime: should never happens in sane conditions
+		panic("rearmPeriodicTimer failed: " + err.Error())
+	}
+	currentTime := time.Unix(currentTimespec.Unix())
+	initial := nextAlignedExpiration(currentTime, s.interval, s.offset)
+	initialTimespec, err := unix.TimeToTimespec(initial)
+	if err != nil {
+		// can only happen on systems having 32-bit timespec when
+		// (roughly) currentTime+interval+offset overflows,
+		// i.e. at the moment just before having system-wide year 2038 apocalypse,
+		// or when the user sets insanely long timer period.
+		panic("rearmPeriodicTimer failed: " + err.Error())
+	}
+	err = s.timerfd.Settime(&unix.ItimerSpec{
+		Interval: unix.NsecToTimespec(s.interval.Nanoseconds()),
+		Value:    initialTimespec,
+	}, nil, true, true)
+	if err != nil {
+		// see man timerfd
+		panic("rearmPeriodicTimer failed: " + err.Error())
+	}
+}
+
+func (s *timerfdScheduler) loop() {
+	// note that s.f is called without holding mutex: it doesn't need it,
+	// and in more general case it should be allowed to call timer methods
+	// without causing a deadlock
+	for {
+		_, err := s.timerfd.Wait()
+		if err != nil {
+			if err == timerfd.ErrTimerfdCancelled {
+				l.Fine("%s: errTimerfdCancelled (discontinuous time change detected)", l.ID(s))
+				s.mu.Lock()
+				f := s.f
+				s.rearmPeriodicTimerLocked()
+				s.mu.Unlock()
+				f()
+			} else if err == os.ErrClosed {
+				// Close has been called
+				return
+			} else {
+				l.Log("%s: timerfd.Wait() returned %v", l.ID(s), err)
+				return
+			}
+		} else {
+			s.mu.Lock()
+			f := s.f
+			s.mu.Unlock()
+			f()
+		}
+	}
+}

--- a/timing/timerfd_scheduler_fallback.go
+++ b/timing/timerfd_scheduler_fallback.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package timing
+
+// NewRealtimeScheduler creates a scheduler backed by system real-time clock.
+//
+// It properly handles system suspend (sleep mode) and time adjustments. For periodic timers,
+// it triggers immediately whenever time changes discontinuously. For one-shot timers
+// (At and After), it will fire immediately if the time is skipped over
+// the set trigger time, and will properly wait for it otherwise.
+//
+// This scheduler is only properly supported on Linux. On other systems,
+// plain scheduler based on "time" package is returned.
+//
+// In order to clean up resources associated with it,
+// remember to call Stop().
+func NewRealtimeScheduler() (*Scheduler, error) {
+	return NewScheduler(), nil
+}

--- a/timing/timerfd_scheduler_test.go
+++ b/timing/timerfd_scheduler_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+
+package timing
+
+import (
+	"testing"
+)
+
+func TestRealtimeTimerfdSchedulerImpl(t *testing.T) {
+	create := func() *Scheduler {
+		s, err := NewRealtimeScheduler()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return s
+	}
+	testSchedulerImplementation(t, create)
+}


### PR DESCRIPTION
Thanks to timerfd, clock will be notified of any discontinuous
adjustments immediately.

This solves clock being incorrect for some time after system suspend
(see issue #150), and also when adjusting clock (NTP or manually).