### PR TITLE
oauth: fix dropped test error

### DIFF
--- a/oauth/crypt_test.go
+++ b/oauth/crypt_test.go
@@ -91,6 +91,7 @@ func TestCryptStore(t *testing.T) {
 	require.Equal(t, oauth2.Token{}, *loaded)
 
 	loaded, err = loadToken("simple.json")
+	require.NoError(t, err)
 	require.Equal(t, oauth2.Token{
 		AccessToken:  "foobar",
 		RefreshToken: "supersecret",


### PR DESCRIPTION
This fixes a dropped test error in the `oauth` package.