### PR TITLE
Handle error when keyring service is missing

### DIFF
--- a/samples/sample-bar/sample-bar.go
+++ b/samples/sample-bar/sample-bar.go
@@ -225,7 +225,10 @@ func setupOauthEncryption() error {
 			return err
 		}
 		secret = base64.RawURLEncoding.EncodeToString(secretBytes)
-		keyring.Set(service, username, secret)
+		err = keyring.Set(service, username, secret)
+		if err != nil {
+			return err
+		}
 	}
 	oauth.SetEncryptionKey(secretBytes)
 	return nil


### PR DESCRIPTION
**How to re-produce the problem**

Install a new system and forget to install seahorse / keyring service. (possible with minimal desktop setup like i3)

Result:

sample-bar (or derivative) will show ERROR instead of github/google/any-oauth content. With adding breakpoints an internal error (` invalid character ... looking for beginning of value`) can be found.

Proposed fix: fail if there is no keyring service.