### PR TITLE
Restore Material Design Icons

### DIFF
--- a/pango/icons/icons.go
+++ b/pango/icons/icons.go
@@ -21,14 +21,14 @@ To use an icon font:
  - Use icons as pango constructs in your bar
 
 Compatible icon fonts:
- - Material Design Icons (community fork)
+ - Material Design Icons (+community fork)
  - FontAwesome
  - Typicons
 
 Example usage:
-  mdi.Load("/Users/me/Github/Templarian/MaterialDesign-Webfont")
+  material.Load("/Users/me/Github/google/material-design-icons")
   ...
-  return pango.Icon("mdi-calendar-today").Color(colors.Hex("#ddd")).
+  return pango.Icon("material-today").Color(colors.Hex("#ddd")).
       Append(pango.Text(now.Sprintf("%H:%M")))
 */
 package icons // import "barista.run/pango/icons"

--- a/pango/icons/material/material.go
+++ b/pango/icons/material/material.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package material provides support for Google's Material Design Icons
+from https://github.com/google/material-design-icons
+
+It uses font/MaterialIcons-Regular.codepoints to get the list of icons,
+and requires font/MaterialIcons-Regular.ttf to be installed.
+*/
+package material // import "barista.run/pango/icons/material"
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"barista.run/pango"
+	"barista.run/pango/icons"
+
+	"github.com/spf13/afero"
+)
+
+var fs = afero.NewOsFs()
+
+// Load initialises the material design icon provider from the given repo.
+func Load(repoPath string) error {
+	f, err := fs.Open(filepath.Join(repoPath, "font/MaterialIcons-Regular.codepoints"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	material := icons.NewProvider("material")
+	material.Font("Material Icons")
+	material.AddStyle(func(n *pango.Node) { n.UltraLight().Rise(-4000) })
+	s := bufio.NewScanner(f)
+	s.Split(bufio.ScanLines)
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		components := strings.Split(line, " ")
+		if len(components) != 2 {
+			return fmt.Errorf("Unexpected line '%s' in 'font/MaterialIcons-Regular.codepoints'", line)
+		}
+		// Material Design Icons uses '_', but all other fonts use '-',
+		// so we'll normalise it here.
+		name := strings.Replace(components[0], "_", "-", -1)
+		value := components[1]
+		err = material.Hex(name, value)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pango/icons/material/material_test.go
+++ b/pango/icons/material/material_test.go
@@ -1,0 +1,87 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package material
+
+import (
+	"testing"
+
+	"barista.run/pango"
+	"barista.run/testing/cron"
+	"barista.run/testing/githubfs"
+	pangoTesting "barista.run/testing/pango"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalid(t *testing.T) {
+	fs = afero.NewMemMapFs()
+	require.Error(t, Load("/src/no-such-directory"))
+
+	afero.WriteFile(fs, "/src/material-error-1/font/MaterialIcons-Regular.codepoints", []byte(
+		`-- Lines in weird formats --
+		 Empty:
+
+		 Valid line:
+		 someIcon 61
+		 otherIcon 62
+		 Invalid codepoint:
+		 badIcon xy`,
+	), 0644)
+	require.Error(t, Load("/src/material-error-1"))
+
+	afero.WriteFile(fs, "/src/material-error-2/iconfont/codepoint", nil, 0644)
+	require.Error(t, Load("/src/material-error-2"))
+
+	afero.WriteFile(fs, "/src/material-error-3/font/MaterialIcons-Regular.codepoints", []byte(
+		`someIcon 61
+		 otherIcon 62
+		 badIcon xy`,
+	), 0644)
+	require.Error(t, Load("/src/material-error-3"))
+}
+
+func TestValid(t *testing.T) {
+	fs = afero.NewMemMapFs()
+	afero.WriteFile(fs, "/src/material/font/MaterialIcons-Regular.codepoints", []byte(
+		`someIcon 61
+		 otherIcon 62
+		 thirdIcon 63`,
+	), 0644)
+	require.NoError(t, Load("/src/material"))
+	pangoTesting.AssertText(t, "a", pango.Icon("material-someIcon").String())
+}
+
+// TestLive tests that current master branch of the icon font works with
+// this package. This test only runs when CI runs tests in 'cron' mode,
+// which provides timely notifications of incompatible changes while
+// keeping default tests hermetic.
+func TestLive(t *testing.T) {
+	fs = githubfs.New()
+	cron.Test(t, func() error {
+		if err := Load("/google/material-design-icons/master"); err != nil {
+			return err
+		}
+		// At least one of these icons should be loaded.
+		testIcons := pango.New(
+			pango.Icon("material-face"),
+			pango.Icon("material-room"),
+			pango.Icon("material-view-agenda"),
+			pango.Icon("material-link-off"),
+		)
+		require.NotEmpty(t, testIcons.String(), "No expected icons were loaded")
+		return nil
+	})
+}

--- a/samples/sample-bar/sample-bar.go
+++ b/samples/sample-bar/sample-bar.go
@@ -56,6 +56,7 @@ import (
 	"barista.run/outputs"
 	"barista.run/pango"
 	"barista.run/pango/icons/fontawesome"
+	"barista.run/pango/icons/material"
 	"barista.run/pango/icons/mdi"
 	"barista.run/pango/icons/typicons"
 
@@ -249,6 +250,7 @@ func threshold(out *bar.Segment, urgent bool, color ...bool) *bar.Segment {
 }
 
 func main() {
+	material.Load(home("Github/material-design-icons"))
 	mdi.Load(home("Github/MaterialDesign-Webfont"))
 	typicons.Load(home("Github/typicons.font"))
 	fontawesome.Load(home("Github/Font-Awesome"))
@@ -273,7 +275,7 @@ func main() {
 	localdate := clock.Local().
 		Output(time.Second, func(now time.Time) bar.Output {
 			return outputs.Pango(
-				pango.Icon("mdi-calendar-today").Alpha(0.6),
+				pango.Icon("material-today").Alpha(0.6),
 				now.Format("Mon Jan 2"),
 			).OnClick(click.RunLeft("gsimplecal"))
 		})
@@ -509,7 +511,7 @@ func main() {
 
 	freeMem := meminfo.New().Output(func(m meminfo.Info) bar.Output {
 		out := outputs.Pango(
-			pango.Icon("mdi-memory").Alpha(0.8),
+			pango.Icon("material-memory").Alpha(0.8),
 			format.IBytesize(m.Available()),
 		)
 		freeGigs := m.Available().Gigabytes()
@@ -653,7 +655,7 @@ func main() {
 		SetOutput(makeIconOutput("typecn-warning-outline")).
 		Detail(wthr)
 	mainModal.Mode("timezones").
-		SetOutput(makeIconOutput("mdi-clock-outline")).
+		SetOutput(makeIconOutput("material-access-time")).
 		Detail(makeTzClock("Seattle", "America/Los_Angeles")).
 		Detail(makeTzClock("New York", "America/New_York")).
 		Detail(makeTzClock("UTC", "Etc/UTC")).

--- a/samples/simple/simple.go
+++ b/samples/simple/simple.go
@@ -50,6 +50,7 @@ import (
 	"barista.run/outputs"
 	"barista.run/pango"
 	"barista.run/pango/icons/fontawesome"
+	"barista.run/pango/icons/material"
 	"barista.run/pango/icons/mdi"
 	"barista.run/pango/icons/typicons"
 
@@ -186,6 +187,7 @@ var gsuiteOauthConfig = []byte(`{"installed": {
 }}`)
 
 func main() {
+	material.Load(home("Github/material-design-icons"))
 	mdi.Load(home("Github/MaterialDesign-Webfont"))
 	typicons.Load(home("Github/typicons.font"))
 	fontawesome.Load(home("Github/Font-Awesome"))
@@ -212,9 +214,9 @@ func main() {
 	localtime := clock.Local().
 		Output(time.Second, func(now time.Time) bar.Output {
 			return outputs.Pango(
-				pango.Icon("mdi-calendar-today").Color(colors.Scheme("dim-icon")),
+				pango.Icon("material-today").Color(colors.Scheme("dim-icon")),
 				now.Format("Mon Jan 2 "),
-				pango.Icon("mdi-clock-outline").Color(colors.Scheme("dim-icon")),
+				pango.Icon("material-access-time").Color(colors.Scheme("dim-icon")),
 				now.Format("15:04:05"),
 			).OnClick(click.RunLeft("gsimplecal"))
 		})
@@ -359,7 +361,7 @@ func main() {
 	})
 
 	freeMem := meminfo.New().Output(func(m meminfo.Info) bar.Output {
-		out := outputs.Pango(pango.Icon("mdi-memory"), format.IBytesize(m.Available()))
+		out := outputs.Pango(pango.Icon("material-memory"), format.IBytesize(m.Available()))
 		freeGigs := m.Available().Gigabytes()
 		switch {
 		case freeGigs < 0.5:


### PR DESCRIPTION
The source repo has been updated to generate the codepoints file again (albeit at a different path).
Update the material package to handle this new format, and restore the use of material icons in the samples.