### PR TITLE
Check the power supply type in sysfs instead of the name to detect batteries

### DIFF
--- a/modules/battery/battery.go
+++ b/modules/battery/battery.go
@@ -19,7 +19,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -310,7 +309,7 @@ func allBatteriesInfo() Info {
 	var infos []Info
 	for _, batt := range batts {
 		powerSupplyTypePath := fmt.Sprintf("/sys/class/power_supply/%s/type", batt)
-		powerSupplyType, err := ioutil.ReadFile(powerSupplyTypePath)
+		powerSupplyType, err := afero.ReadFile(fs, powerSupplyTypePath)
 		if err != nil {
 			continue
 		}

--- a/modules/battery/battery.go
+++ b/modules/battery/battery.go
@@ -17,7 +17,9 @@ package battery // import "barista.run/modules/battery"
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"strconv"
 	"strings"
@@ -307,7 +309,12 @@ func allBatteriesInfo() Info {
 	}
 	var infos []Info
 	for _, batt := range batts {
-		if !strings.HasPrefix(batt, "BAT") {
+		powerSupplyTypePath := fmt.Sprintf("/sys/class/power_supply/%s/type", batt)
+		powerSupplyType, err := ioutil.ReadFile(powerSupplyTypePath)
+		if err != nil {
+			continue
+		}
+		if !bytes.Equal([]byte("Battery\n"), powerSupplyType) {
 			continue
 		}
 		infos = append(infos, batteryInfo(batt))

--- a/modules/battery/battery_test.go
+++ b/modules/battery/battery_test.go
@@ -17,6 +17,7 @@ package battery
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,14 @@ func write(battery battery) {
 		"/sys/class/power_supply/%s/uevent",
 		battery["NAME"].(string))
 	afero.WriteFile(fs, batteryFile, buffer.Bytes(), 0644)
+	batteryTypeFile := fmt.Sprintf(
+		"/sys/class/power_supply/%s/type",
+		battery["NAME"].(string))
+	if strings.HasPrefix(battery["NAME"].(string), "BAT") {
+		afero.WriteFile(fs, batteryTypeFile, []byte("Battery\n"), 0644)
+	} else {
+		afero.WriteFile(fs, batteryTypeFile, []byte("Mains\n"), 0644)
+	}
 }
 
 func TestDisconnected(t *testing.T) {


### PR DESCRIPTION
The name in `/sys/class/power_supply` is not always `BAT*`.