### PR TITLE
Also correctly calculate battery state with limited driver.

### DIFF
--- a/modules/battery/battery_test.go
+++ b/modules/battery/battery_test.go
@@ -180,6 +180,19 @@ func TestSimple(t *testing.T) {
 		"CAPACITY":           50,
 	})
 
+	// (Pinebook Pro) example without CHARGE_NOW
+	write(battery{
+		"NAME":               "BAT3",
+		"STATUS":             "Discharging",
+		"PRESENT":            1,
+		"TECHNOLOGY":         "Li-ion",
+		"VOLTAGE_NOW":        20 * micros,
+		"CURRENT_NOW":        int(0.5 * float64(micros)),
+		"CHARGE_FULL_DESIGN": 5 * micros,
+		"CHARGE_FULL":        int(4.4 * float64(micros)),
+		"CAPACITY":           50,
+	})
+
 	info := batteryInfo("BAT0")
 	require.Equal(Charging, info.Status)
 	require.Equal("Li-poly", info.Technology)
@@ -198,6 +211,13 @@ func TestSimple(t *testing.T) {
 	require.True(info.PluggedIn())
 
 	info = batteryInfo("BAT2")
+	require.InDelta(20.0, info.Voltage, 0.01)
+	require.InDelta(100.0, info.EnergyMax, 0.01)
+	require.InDelta(88.0, info.EnergyFull, 0.01)
+	require.InDelta(44.0, info.EnergyNow, 0.01)
+	require.False(info.PluggedIn())
+
+	info = batteryInfo("BAT3")
 	require.InDelta(20.0, info.Voltage, 0.01)
 	require.InDelta(100.0, info.EnergyMax, 0.01)
 	require.InDelta(88.0, info.EnergyFull, 0.01)


### PR DESCRIPTION
Not all drivers implement ENERGY_NOW and/or CHARGE_NOW. This patch falls back on CAPACITY. This issue is [also a problem on waybar](https://github.com/Alexays/Waybar/issues/966). Now barista works perfectly fine on my Pinebook Pro.