### PR TITLE
add control of pulseaudio sources

### DIFF
--- a/modules/volume/pulseaudio/pulse.go
+++ b/modules/volume/pulseaudio/pulse.go
@@ -28,8 +28,10 @@ import (
 type deviceType int
 
 const (
-	SinkDevice deviceType = iota // Sinks (audio outputs, e.g. headphones)
-	SourceDevice // Sources (audio inputs, e.g. microphones)
+	// SinkDevice represents devices used for audio output, e.g. headphones.
+	SinkDevice deviceType = iota
+	// SourceDevice represents devices used for audio input, e.g. microphones.
+	SourceDevice
 )
 
 func (deviceType deviceType) String() string {


### PR DESCRIPTION
This adds handling of PulseAudio sources (audio inputs, e.g. microphones) in the `volume/pulseaudio` module. Previously only sinks (audio outputs, e.g. headphones) were supported.
It replaces all functions working with sinks to functions working with devices, and redefines sinks as specific devices.
To the already existing `Sink(sinkName string)` and `DefaultSink()` volume providers are added the `Device(deviceName string, deviceType DeviceType)`, `Source(sourceName string)` and `DefaultSource()` volume providers.

Note that on my machine the actual volume of the microphone I get with `Pct()` is 10 times that of the actual volume I see in my settings, but this seems to be an issue with the PulseAudio API.