### PR TITLE
Add hwmon module

### DIFF
--- a/modules/cputemp/cputemp.go
+++ b/modules/cputemp/cputemp.go
@@ -16,44 +16,17 @@
 package cputemp // import "barista.run/modules/cputemp"
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-	"time"
-
-	"barista.run/bar"
-	"barista.run/base/value"
-	l "barista.run/logging"
-	"barista.run/outputs"
-	"barista.run/timing"
-
-	"github.com/martinlindhe/unit"
-	"github.com/spf13/afero"
+	"barista.run/modules/internal/temperature"
 )
 
 // Module represents a cputemp bar module. It supports setting the output
 // format, click handler, update frequency, and urgency/colour functions.
-type Module struct {
-	thermalFile string
-	scheduler   *timing.Scheduler
-	outputFunc  value.Value // of func(unit.Temperature) bar.Output
-}
+type Module = temperature.Module
 
 // Zone constructs an instance of the cputemp module for the specified zone.
 // The file /sys/class/thermal/<zone>/temp should return cpu temp in 1/1000 deg C.
 func Zone(thermalZone string) *Module {
-	m := &Module{
-		thermalFile: fmt.Sprintf("/sys/class/thermal/%s/temp", thermalZone),
-		scheduler:   timing.NewScheduler(),
-	}
-	l.Label(m, thermalZone)
-	l.Register(m, "scheduler", "format")
-	m.RefreshInterval(3 * time.Second)
-	// Default output, if no function is specified later.
-	m.Output(func(t unit.Temperature) bar.Output {
-		return outputs.Textf("%.1f℃", t.Celsius())
-	})
-	return m
+	return temperature.ThermalZone(thermalZone)
 }
 
 // OfType constructs an instance of the cputemp module for the *first* available
@@ -61,68 +34,11 @@ func Zone(thermalZone string) *Module {
 // of the actual CPU package, while others may be available depending on the
 // system, e.g. "iwlwifi" for wifi, or "acpitz" for the motherboard.
 func OfType(typ string) *Module {
-	files, _ := afero.ReadDir(fs, "/sys/class/thermal")
-	for _, file := range files {
-		name := file.Name()
-		typFile := fmt.Sprintf("/sys/class/thermal/%s/type", name)
-		typBytes, _ := afero.ReadFile(fs, typFile)
-		if strings.TrimSpace(string(typBytes)) == typ {
-			return Zone(name)
-		}
-	}
-	return Zone("")
+	return temperature.ThermalOfType(typ)
 }
 
 // New constructs an instance of the cputemp module for zone type "x86_pkg_temp".
 // Returns nil of the x86_pkg_temp thermal zone is unavailable.
 func New() *Module {
-	return OfType("x86_pkg_temp")
-}
-
-// Output configures a module to display the output of a user-defined function.
-func (m *Module) Output(outputFunc func(unit.Temperature) bar.Output) *Module {
-	m.outputFunc.Set(outputFunc)
-	return m
-}
-
-// RefreshInterval configures the polling frequency for cpu temperatures.
-// Note: updates might still be less frequent if the temperature does not change.
-func (m *Module) RefreshInterval(interval time.Duration) *Module {
-	m.scheduler.Every(interval)
-	return m
-}
-
-var fs = afero.NewOsFs()
-
-// Stream starts the module.
-func (m *Module) Stream(s bar.Sink) {
-	temp, err := getTemperature(m.thermalFile)
-	outputFunc := m.outputFunc.Get().(func(unit.Temperature) bar.Output)
-	nextOutputFunc, done := m.outputFunc.Subscribe()
-	defer done()
-	for {
-		if s.Error(err) {
-			return
-		}
-		s.Output(outputFunc(temp))
-		select {
-		case <-m.scheduler.C:
-			temp, err = getTemperature(m.thermalFile)
-		case <-nextOutputFunc:
-			outputFunc = m.outputFunc.Get().(func(unit.Temperature) bar.Output)
-		}
-	}
-}
-
-func getTemperature(thermalFile string) (unit.Temperature, error) {
-	bytes, err := afero.ReadFile(fs, thermalFile)
-	if err != nil {
-		return 0, err
-	}
-	value := strings.TrimSpace(string(bytes))
-	milliC, err := strconv.Atoi(value)
-	if err != nil {
-		return 0, err
-	}
-	return unit.FromCelsius(float64(milliC) / 1000.0), nil
+	return temperature.NewDefaultThermal()
 }

--- a/modules/hwmon/hwmon.go
+++ b/modules/hwmon/hwmon.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hwmon implements an i3bar module that shows the temperature from /sys/class/hwmon
+package hwmon // import "barista.run/modules/cputemp"
+
+import (
+	"barista.run/modules/internal/temperature"
+)
+
+// Module represents a hwmon bar module. It supports setting the output
+// format, click handler, update frequency, and urgency/colour functions.
+type Module = temperature.Module
+
+// OfNameAndLabel finds a sensor given hwmon name and label.
+//
+// For example, if you have /sys/class/hwmon/hwmon4/name containing
+// "k10temp", and /sys/class/hwmon/hwmon4/temp1_label containing
+// "Tctl", the former would be name, and the latter would be label.
+func OfNameAndLabel(name string, label string) *Module {
+	return temperature.HwmonOfNameAndLabel(name, label)
+}

--- a/modules/internal/temperature/hwmon.go
+++ b/modules/internal/temperature/hwmon.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package temperature
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// HwmonOfNameAndLabel finds a sensor given hwmon name and label.
+//
+// For example, if you have /sys/class/hwmon/hwmon4/name containing
+// "k10temp", and /sys/class/hwmon/hwmon4/temp1_label containing
+// "Tctl", the former would be name, and the latter would be label.
+func HwmonOfNameAndLabel(name string, label string) *Module {
+	baseDir := "/sys/class/hwmon"
+	files, _ := afero.ReadDir(fs, baseDir)
+	for _, file := range files {
+		n, _ := afero.ReadFile(fs, filepath.Join(baseDir, file.Name(), "name"))
+		if strings.TrimSpace(string(n)) == name {
+			baseDir := filepath.Join(baseDir, file.Name())
+			files, _ := afero.ReadDir(fs, filepath.Join(baseDir))
+			for _, file := range files {
+				if strings.HasSuffix(file.Name(), "_label") {
+					l, _ := afero.ReadFile(fs, filepath.Join(baseDir, file.Name()))
+					if strings.TrimSpace(string(l)) == label {
+						filename := file.Name()
+						filename = strings.TrimSuffix(filename, "_label") + "_input"
+						return newModule(filepath.Join(baseDir, filename))
+					}
+				}
+			}
+		}
+	}
+	return newModule("")
+}

--- a/modules/internal/temperature/hwmon_test.go
+++ b/modules/internal/temperature/hwmon_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package temperature
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHwmonDetection(t *testing.T) {
+	fs = afero.NewMemMapFs()
+	contents := []struct {
+		path string
+		data string
+	}{
+		{"/sys/class/hwmon/hwmon0/name", "k10temp\n"},
+		{"/sys/class/hwmon/hwmon0/temp1_label", "Tctl\n"},
+		{"/sys/class/hwmon/hwmon0/temp1_input", "63500\n"},
+		{"/sys/class/hwmon/hwmon1/name", "amdgpu\n"},
+		{"/sys/class/hwmon/hwmon1/temp1_label", "edge\n"},
+		{"/sys/class/hwmon/hwmon1/temp2_label", "junction\n"},
+		{"/sys/class/hwmon/hwmon1/temp3_label", "mem\n"},
+		{"/sys/class/hwmon/hwmon1/temp1_input", "56000\n"},
+		{"/sys/class/hwmon/hwmon1/temp2_input", "56000\n"},
+		{"/sys/class/hwmon/hwmon1/temp3_input", "56000\n"},
+	}
+	for _, content := range contents {
+		err := afero.WriteFile(fs, content.path, []byte(content.data), 0644)
+		require.NoError(t, err)
+	}
+	// This only tests detection code.
+	// functional tests are in thermalzone_test.go
+	var m *Module
+	m = HwmonOfNameAndLabel("k10temp", "Tctl")
+	assert.Equal(t, "/sys/class/hwmon/hwmon0/temp1_input", m.thermalFile)
+	m = HwmonOfNameAndLabel("amdgpu", "junction")
+	assert.Equal(t, "/sys/class/hwmon/hwmon1/temp2_input", m.thermalFile)
+}

--- a/modules/internal/temperature/module.go
+++ b/modules/internal/temperature/module.go
@@ -1,0 +1,101 @@
+// Copyright 2017, 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package temperature
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"barista.run/bar"
+	"barista.run/base/value"
+	l "barista.run/logging"
+	"barista.run/outputs"
+	"barista.run/timing"
+
+	"github.com/martinlindhe/unit"
+	"github.com/spf13/afero"
+)
+
+// Module represents a cputemp bar module. It supports setting the output
+// format, click handler, update frequency, and urgency/colour functions.
+type Module struct {
+	thermalFile string
+	scheduler   *timing.Scheduler
+	outputFunc  value.Value // of func(unit.Temperature) bar.Output
+}
+
+func newModule(thermalFile string) *Module {
+	m := &Module{
+		thermalFile: thermalFile,
+		scheduler:   timing.NewScheduler(),
+	}
+	l.Label(m, thermalFile)
+	l.Register(m, "scheduler", "format")
+	m.RefreshInterval(3 * time.Second)
+	// Default output, if no function is specified later.
+	m.Output(func(t unit.Temperature) bar.Output {
+		return outputs.Textf("%.1f℃", t.Celsius())
+	})
+	return m
+}
+
+// Output configures a module to display the output of a user-defined function.
+func (m *Module) Output(outputFunc func(unit.Temperature) bar.Output) *Module {
+	m.outputFunc.Set(outputFunc)
+	return m
+}
+
+// RefreshInterval configures the polling frequency for cpu temperatures.
+// Note: updates might still be less frequent if the temperature does not change.
+func (m *Module) RefreshInterval(interval time.Duration) *Module {
+	m.scheduler.Every(interval)
+	return m
+}
+
+var fs = afero.NewOsFs()
+
+// Stream starts the module.
+func (m *Module) Stream(s bar.Sink) {
+	temp, err := getTemperature(m.thermalFile)
+	outputFunc := m.outputFunc.Get().(func(unit.Temperature) bar.Output)
+	nextOutputFunc, done := m.outputFunc.Subscribe()
+	defer done()
+	for {
+		if s.Error(err) {
+			return
+		}
+		s.Output(outputFunc(temp))
+		select {
+		case <-m.scheduler.C:
+			temp, err = getTemperature(m.thermalFile)
+		case <-nextOutputFunc:
+			outputFunc = m.outputFunc.Get().(func(unit.Temperature) bar.Output)
+		}
+	}
+}
+
+func getTemperature(thermalFile string) (unit.Temperature, error) {
+	bytes, err := afero.ReadFile(fs, thermalFile)
+	if err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(bytes))
+	milliC, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, err
+	}
+	return unit.FromCelsius(float64(milliC) / 1000.0), nil
+}

--- a/modules/internal/temperature/thermalzone.go
+++ b/modules/internal/temperature/thermalzone.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package temperature
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+// ThermalZone constructs an instance of the temperature module for the specified zone.
+// The file /sys/class/thermal/<zone>/temp should return cpu temp in 1/1000 deg C.
+func ThermalZone(thermalZone string) *Module {
+	return newModule(fmt.Sprintf("/sys/class/thermal/%s/temp", thermalZone))
+}
+
+// ThermalOfType constructs an instance of the cputemp module for the *first*
+// available sensor of the given type. "x86_pkg_temp" usually represents the temperature
+// of the actual CPU package, while others may be available depending on the
+// system, e.g. "iwlwifi" for wifi, or "acpitz" for the motherboard.
+func ThermalOfType(typ string) *Module {
+	files, _ := afero.ReadDir(fs, "/sys/class/thermal")
+	for _, file := range files {
+		name := file.Name()
+		typFile := fmt.Sprintf("/sys/class/thermal/%s/type", name)
+		typBytes, _ := afero.ReadFile(fs, typFile)
+		if strings.TrimSpace(string(typBytes)) == typ {
+			return ThermalZone(name)
+		}
+	}
+	return ThermalZone("")
+}
+
+// NewDefaultThermal constructs an instance of the cputemp module for zone type
+// "x86_pkg_temp". Returns nil of the x86_pkg_temp thermal zone is unavailable.
+func NewDefaultThermal() *Module {
+	return ThermalOfType("x86_pkg_temp")
+}


### PR DESCRIPTION
On Linux, `/sys/class/hwmon` usually has more sensors than `/sys/class/thermal`.

Since `hwmon` and `cputemp` share a lot of code, all the implementation and tests are moved into a new internal package, and `hwmon` and `cputemp` modules simply call into said package.

`cputemp` probably should've been called `thermal`, but I decided against a breaking change.

Closes #247