### PR TITLE
Use native PulseAudio protocol for volume module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fsnotify/fsnotify v1.5.4
 	github.com/godbus/dbus/v5 v5.1.0
+	github.com/jfreymuth/pulse v0.1.1-0.20221101213618-75628dabd933
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/martinlindhe/unit v0.0.0-20190604142932-3b6be53d49af
 	github.com/maximbaz/yubikey-touch-detector v0.0.0-20200307130350-24f6f7449a30

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jfreymuth/pulse v0.1.1-0.20221101213618-75628dabd933 h1:lKQ+1dFw4AC+2hzyiQ0AvOP1KW74dOkC8hZXdzea31M=
+github.com/jfreymuth/pulse v0.1.1-0.20221101213618-75628dabd933/go.mod h1:cpYspI6YljhkUf1WLXLLDmeaaPFc3CnGLjDZf9dZ4no=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/modules/volume/pulseaudio/pulse.go
+++ b/modules/volume/pulseaudio/pulse.go
@@ -15,14 +15,13 @@
 package pulseaudio
 
 import (
-	"C"
 	"fmt"
 	"os"
 
 	"barista.run/base/value"
 	"barista.run/modules/volume"
 
-	"github.com/godbus/dbus/v5"
+	"github.com/jfreymuth/pulse/proto"
 )
 
 type deviceType int
@@ -44,53 +43,9 @@ type paModule struct {
 	deviceType deviceType
 }
 
-type paController struct {
-	device dbus.BusObject
-}
-
-func dialAndAuth(addr string) (*dbus.Conn, error) {
-	conn, err := dbus.Dial(addr)
-	if err != nil {
-		return nil, err
-	}
-	err = conn.Auth(nil)
-	if err != nil {
-		return nil, err
-	}
-	return conn, nil
-}
-
-func openPulseAudio() (*dbus.Conn, error) {
-	// Pulse defaults to creating its socket in a well-known place under
-	// XDG_RUNTIME_DIR. For Pulse instances created by systemd, this is the
-	// only reliable way to contact Pulse via D-Bus, since Pulse is created
-	// on a per-user basis, but the session bus is created once for every
-	// session, and a user can have multiple sessions.
-	xdgDir := os.Getenv("XDG_RUNTIME_DIR")
-	if xdgDir != "" {
-		addr := fmt.Sprintf("unix:path=%s/pulse/dbus-socket", xdgDir)
-		return dialAndAuth(addr)
-	}
-
-	// Couldn't find the PulseAudio bus on the fast path, so look for it
-	// by querying the session bus.
-	bus, err := dbus.SessionBusPrivate()
-	if err != nil {
-		return nil, err
-	}
-	defer bus.Close()
-	err = bus.Auth(nil)
-	if err != nil {
-		return nil, err
-	}
-
-	locator := bus.Object("org.PulseAudio1", "/org/pulseaudio/server_lookup1")
-	path, err := locator.GetProperty("org.PulseAudio.ServerLookup1.Address")
-	if err != nil {
-		return nil, err
-	}
-
-	return dialAndAuth(path.Value().(string))
+func openPulseAudio() (*proto.Client, error) {
+	client, _, err := proto.Connect("")
+	return client, err
 }
 
 // Device creates a PulseAduio volume module for a named device that can either be a sink or a source.
@@ -105,7 +60,7 @@ func Sink(sinkName string) volume.Provider {
 
 // DefaultSink creates a PulseAudio volume module that follows the default sink.
 func DefaultSink() volume.Provider {
-	return Sink("")
+	return Sink("@DEFAULT_SINK@")
 }
 
 // Source creates a PulseAudio volume module for a named source.
@@ -115,131 +70,141 @@ func Source(sourceName string) volume.Provider {
 
 // DefaultSource creates a PulseAudio volume module that follows the default source.
 func DefaultSource() volume.Provider {
-	return Source("")
+	return Source("@DEFAULT_SOURCE@")
 }
 
-func (c *paController) SetVolume(newVol int64) error {
-	return c.device.Call(
-		"org.freedesktop.DBus.Properties.Set",
-		0,
-		"org.PulseAudio.Core1.Device",
-		"Volume",
-		dbus.MakeVariant([]uint32{uint32(newVol)}),
-	).Err
+type sinkController struct {
+	client     *proto.Client
+	deviceName string
 }
 
-func (c *paController) SetMuted(muted bool) error {
-	return c.device.Call(
-		"org.freedesktop.DBus.Properties.Set",
-		0,
-		"org.PulseAudio.Core1.Device",
-		"Mute",
-		dbus.MakeVariant(muted),
-	).Err
+type sourceController struct {
+	client     *proto.Client
+	deviceName string
 }
 
-func listen(core dbus.BusObject, signal string, objects ...dbus.ObjectPath) error {
-	return core.Call(
-		"org.PulseAudio.Core1.ListenForSignal",
-		0,
-		"org.PulseAudio.Core1."+signal,
-		objects,
-	).Err
+func (c *sinkController) SetVolume(newVol int64) (err error) {
+	return c.client.Request(&proto.SetSinkVolume{
+		SinkIndex:      proto.Undefined,
+		SinkName:       c.deviceName,
+		ChannelVolumes: proto.ChannelVolumes{uint32(newVol)},
+	}, nil)
 }
 
-func openDevice(conn *dbus.Conn, core dbus.BusObject, devicePath dbus.ObjectPath, deviceType deviceType) (dbus.BusObject, error) {
-	device := conn.Object("org.PulseAudio.Core1."+deviceType.String(), devicePath)
-	if err := listen(core, "Device.VolumeUpdated", devicePath); err != nil {
-		return nil, err
+func (c *sourceController) SetVolume(newVol int64) (err error) {
+	return c.client.Request(&proto.SetSourceVolume{
+		SourceIndex:    proto.Undefined,
+		SourceName:     c.deviceName,
+		ChannelVolumes: proto.ChannelVolumes{uint32(newVol)},
+	}, nil)
+}
+
+func (c *sinkController) SetMuted(muted bool) (err error) {
+	return c.client.Request(&proto.SetSinkMute{
+		SinkIndex: proto.Undefined,
+		SinkName:  c.deviceName,
+		Mute:      muted,
+	}, nil)
+}
+
+func (c *sourceController) SetMuted(muted bool) (err error) {
+	return c.client.Request(&proto.SetSourceMute{
+		SourceIndex: proto.Undefined,
+		SourceName:  c.deviceName,
+		Mute:        muted,
+	}, nil)
+}
+
+func getVolume(client *proto.Client, deviceName string, deviceType deviceType) (vol volume.Volume, err error) {
+	switch deviceType {
+	case SinkDevice:
+		return getVolumeSink(client, deviceName)
+	case SourceDevice:
+		return getVolumeSource(client, deviceName)
+	default:
+		panic(fmt.Sprintf("unexpected device type %v", int(deviceType)))
 	}
-	return device, listen(core, "Device.MuteUpdated", devicePath)
 }
 
-func openDeviceByName(conn *dbus.Conn, core dbus.BusObject, name string, deviceType deviceType) (dbus.BusObject, error) {
-	var path dbus.ObjectPath
-	err := core.Call("org.PulseAudio.Core1.Get"+deviceType.String()+"ByName", 0, name).Store(&path)
+func getVolumeSink(client *proto.Client, deviceName string) (vol volume.Volume, err error) {
+	repl := proto.GetSinkInfoReply{}
+	err = client.Request(&proto.GetSinkInfo{SinkIndex: proto.Undefined, SinkName: deviceName}, &repl)
 	if err != nil {
-		return nil, err
+		return
 	}
-	return openDevice(conn, core, path, deviceType)
+	return makeVolume(repl.ChannelVolumes, repl.Mute, &sinkController{client, deviceName}), nil
 }
 
-func openFallbackDevice(conn *dbus.Conn, core dbus.BusObject, deviceType deviceType) (dbus.BusObject, error) {
-	path, err := core.GetProperty("org.PulseAudio.Core1.Fallback" + deviceType.String())
+func getVolumeSource(client *proto.Client, deviceName string) (vol volume.Volume, err error) {
+	repl := proto.GetSourceInfoReply{}
+	err = client.Request(&proto.GetSourceInfo{SourceIndex: proto.Undefined, SourceName: deviceName}, &repl)
 	if err != nil {
-		return nil, err
+		return
 	}
-	return openDevice(conn, core, path.Value().(dbus.ObjectPath), deviceType)
+	return makeVolume(repl.ChannelVolumes, repl.Mute, &sourceController{client, deviceName}), nil
 }
 
-func getVolume(device dbus.BusObject) (volume.Volume, error) {
-	max, err := device.GetProperty("org.PulseAudio.Core1.Device.BaseVolume")
-	if err != nil {
-		return volume.Volume{}, err
-	}
-	maxVol := int64(max.Value().(uint32))
-
-	vol, err := device.GetProperty("org.PulseAudio.Core1.Device.Volume")
-	if err != nil {
-		return volume.Volume{}, err
-	}
-
+func makeVolume(channelVolumes proto.ChannelVolumes, mute bool, controller volume.Controller) volume.Volume {
 	// Take the volume as the average across all channels.
 	var totalVol int64
-	channels := vol.Value().([]uint32)
-	for _, ch := range channels {
+	for _, ch := range channelVolumes {
 		totalVol += int64(ch)
 	}
-	currentVol := totalVol / int64(len(channels))
-
-	mute, err := device.GetProperty("org.PulseAudio.Core1.Device.Mute")
-	if err != nil {
-		return volume.Volume{}, err
-	}
-	muted := mute.Value().(bool)
-
-	return volume.MakeVolume(0, maxVol, currentVol, muted, &paController{device}), nil
+	currentVol := totalVol / int64(len(channelVolumes))
+	return volume.MakeVolume(0, int64(proto.VolumeNorm), currentVol, mute, controller)
 }
 
 func (m *paModule) Worker(s *value.ErrorValue) {
-	conn, err := openPulseAudio()
+	client, conn, err := proto.Connect("")
 	if s.Error(err) {
 		return
 	}
 	defer conn.Close()
 
-	core := conn.Object("org.PulseAudio.Core1", "/org/pulseaudio/core1")
+	ch := make(chan struct{}, 1)
 
-	var device dbus.BusObject
-	if m.deviceName != "" {
-		device, err = openDeviceByName(conn, core, m.deviceName, m.deviceType)
-	} else {
-		device, err = openFallbackDevice(conn, core, m.deviceType)
-		if err == nil {
-			err = listen(core, "Fallback"+m.deviceType.String()+"Updated")
+	client.Callback = func(val interface{}) {
+		switch val.(type) {
+		case *proto.SubscribeEvent:
+			// When PulseAudio server notifies us about sink/source change,
+			// refresh the volume.
+			//
+			// It's okay if we lose notification something due to channel
+			// being full though: this means that refresh is already pending.
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
 		}
 	}
+
+	props := proto.PropList{
+		"application.name":           proto.PropListString("barista"),
+		"application.process.binary": proto.PropListString(os.Args[0]),
+		"application.process.id":     proto.PropListString(fmt.Sprintf("%d", os.Getpid())),
+	}
+
+	err = client.Request(&proto.SetClientName{Props: props}, nil)
 	if s.Error(err) {
 		return
 	}
-	if s.SetOrError(getVolume(device)) {
+
+	var mask proto.SubscriptionMask
+	switch m.deviceType {
+	case SinkDevice:
+		mask |= proto.SubscriptionMaskSink
+	case SourceDevice:
+		mask |= proto.SubscriptionMaskSource
+	}
+	err = client.Request(&proto.Subscribe{Mask: mask}, nil)
+	if s.Error(err) {
 		return
 	}
 
-	signals := make(chan *dbus.Signal, 10)
-	conn.Signal(signals)
-
-	// Listen for signals from D-Bus, and update appropriately.
-	for signal := range signals {
-		// If the fallback device changed, open the new one.
-		if m.deviceName == "" && signal.Path == core.Path() {
-			device, err = openFallbackDevice(conn, core, m.deviceType)
-			if s.Error(err) {
-				return
-			}
-		}
-		if s.SetOrError(getVolume(device)) {
+	for {
+		if s.SetOrError(getVolume(client, m.deviceName, m.deviceType)) {
 			return
 		}
+		<-ch
 	}
 }


### PR DESCRIPTION
Most importantly, PipeWire does not have module-dbus-protocol implemented at all[1], so barista didn't work with PipeWire.

Note that PipeWire does implement native PulseAudio protocol - and that's how most applications interface with PipeWire, using it for streaming audio, sink/source control (pavucontrol), etc. PipeWire's own native protocol is not frequently used as of yet.

Secondly, module-dbus-protocol is frequently not loaded by default on PulseAudio, necessitating explicit "pactl load-module module-dbus-protocol".

[1] https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/1127

Fixes #302