### PR TITLE
Ignore No such entity error in PulseAudio module

### DIFF
--- a/modules/volume/pulseaudio/pulse.go
+++ b/modules/volume/pulseaudio/pulse.go
@@ -202,8 +202,12 @@ func (m *paModule) Worker(s *value.ErrorValue) {
 	}
 
 	for {
-		if s.SetOrError(getVolume(client, m.deviceName, m.deviceType)) {
-			return
+		vol, err := getVolume(client, m.deviceName, m.deviceType)
+		// Ignore ErrNoSuchEntity because devices may easily go away.
+		if err != proto.ErrNoSuchEntity {
+			if s.SetOrError(vol, err) {
+				return
+			}
 		}
 		<-ch
 	}


### PR DESCRIPTION
First, if some specific sink/source is specified, it may easily go away (e.g. external sound card).

Second, even `@DEFAULT_SOURCE@`/`@DEFAULT_SINK@` may go away if current seat becomes inactive, and udev revokes device access (simple way to reproduce is Ctrl+Alt+F1).