### PR TITLE
Update `Pango` markup link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site
 Gemfile.lock
 .bundle
+./idea

--- a/index.md
+++ b/index.md
@@ -93,7 +93,7 @@ returns the output to be displayed on the bar. Some simple output functions are 
 [`outputs`](/outputs) package.
 
 When using a pango font, i3bar also supports
-[Pango Markup](https://developer.gnome.org/pygtk/stable/pango-markup-language.html), which can be used
+[Pango Markup](https://docs.gtk.org/Pango/pango_markup.html), which can be used
 for rich in-line text formatting and icon fonts. Barista provides the [`pango`](/pango) package for
 constructing and manipulating output that uses pango markup.
 

--- a/pango.md
+++ b/pango.md
@@ -3,7 +3,7 @@ title: Pango Formatting
 ---
 
 When using a Pango font, i3bar supports formatting the output using
-[Pango Markup](https://developer.gnome.org/pygtk/stable/pango-markup-language.html). This allows rich
+[Pango Markup](https://docs.gtk.org/Pango/pango_markup.html). This allows rich
 in-line formatting in each segment of the output.
 
 Barista provides formatting primitives that allow type-safe construction of markup strings,

--- a/pango/icons.md
+++ b/pango/icons.md
@@ -3,7 +3,7 @@ title: Icon Fonts
 pkg: noimport
 ---
 
-Although i3bar can only display text, it supports [Pango Markup](https://developer.gnome.org/pygtk/stable/pango-markup-language.html),
+Although i3bar can only display text, it supports [Pango Markup](https://docs.gtk.org/Pango/pango_markup.html),
 which means that any icon font installed on the system can be used to add pictograms to the bar.
 
 There are a few simple steps to using an icon font in your bar:


### PR DESCRIPTION
I noticed that the link for `Pango` markup in the documentation is outdated. I have updated it to the current link to ensure accuracy.